### PR TITLE
Short circuit on empty $CPPUNIT_FQ_DIR

### DIFF
--- a/Modules/FindCppUnit.cmake
+++ b/Modules/FindCppUnit.cmake
@@ -6,11 +6,9 @@ FindCppUnit
 include(CetFindPkgConfigPackage)
 include(FindPackageHandleStandardArgs)
 
-if ($ENV{CPPUNIT_FQ_DIR})
-  if (EXISTS "$ENV{CPPUNIT_FQ_DIR}/lib/pkgconfig/cppunit.pc")
-    # Older cppunit UPS table files added the wrong directory to PKG_CONFIG_PATH.
-    set(ENV{PKG_CONFIG_PATH} "$ENV{CPPUNIT_FQ_DIR}/lib/pkgconfig:$ENV{PKG_CONFIG_PATH}")
-  endif()
+if ("$ENV{CPPUNIT_FQ_DIR}" AND EXISTS "$ENV{CPPUNIT_FQ_DIR}/lib/pkgconfig/cppunit.pc")
+  # Older cppunit UPS table files added the wrong directory to PKG_CONFIG_PATH.
+  set(ENV{PKG_CONFIG_PATH} "$ENV{CPPUNIT_FQ_DIR}/lib/pkgconfig:$ENV{PKG_CONFIG_PATH}")
 endif()
 set(_cet_findcppunit_required ${${CMAKE_FIND_PACKAGE_NAME}_FIND_REQUIRED})
 set(${CMAKE_FIND_PACKAGE_NAME}_FIND_REQUIRED)

--- a/Modules/FindCppUnit.cmake
+++ b/Modules/FindCppUnit.cmake
@@ -6,9 +6,11 @@ FindCppUnit
 include(CetFindPkgConfigPackage)
 include(FindPackageHandleStandardArgs)
 
-if ($ENV{CPPUNIT_FQ_DIR} AND EXISTS "$ENV{CPPUNIT_FQ_DIR}/lib/pkgconfig/cppunit.pc")
-  # Older cppunit UPS table files added the wrong directory to PKG_CONFIG_PATH.
-  set(ENV{PKG_CONFIG_PATH} "$ENV{CPPUNIT_FQ_DIR}/lib/pkgconfig:$ENV{PKG_CONFIG_PATH}")
+if ($ENV{CPPUNIT_FQ_DIR})
+  if (EXISTS "$ENV{CPPUNIT_FQ_DIR}/lib/pkgconfig/cppunit.pc")
+    # Older cppunit UPS table files added the wrong directory to PKG_CONFIG_PATH.
+    set(ENV{PKG_CONFIG_PATH} "$ENV{CPPUNIT_FQ_DIR}/lib/pkgconfig:$ENV{PKG_CONFIG_PATH}")
+  endif()
 endif()
 set(_cet_findcppunit_required ${${CMAKE_FIND_PACKAGE_NAME}_FIND_REQUIRED})
 set(${CMAKE_FIND_PACKAGE_NAME}_FIND_REQUIRED)


### PR DESCRIPTION
I was having an issue in a non-ups environment where [FindCppUnit.cmake#L9](https://github.com/FNALssi/cetmodules/blob/a59e334303c07c8b7dd1d773b79386702ef47084/Modules/FindCppUnit.cmake#L9) was not short circuiting and instead throwing an error when $CPPUNIT_FQ_DIR was empty
This may not be the cleanest way to fix it, but it does properly short circuit now. Perhaps adding quotations around $ENV{CPPUNIT_FQ_DIR} is another way to get the desired behavior?