### PR TITLE
Change check for ups setup

### DIFF
--- a/Modules/FindCppUnit.cmake
+++ b/Modules/FindCppUnit.cmake
@@ -6,9 +6,11 @@ FindCppUnit
 include(CetFindPkgConfigPackage)
 include(FindPackageHandleStandardArgs)
 
-if ("$ENV{CPPUNIT_FQ_DIR}" AND EXISTS "$ENV{CPPUNIT_FQ_DIR}/lib/pkgconfig/cppunit.pc")
-  # Older cppunit UPS table files added the wrong directory to PKG_CONFIG_PATH.
-  set(ENV{PKG_CONFIG_PATH} "$ENV{CPPUNIT_FQ_DIR}/lib/pkgconfig:$ENV{PKG_CONFIG_PATH}")
+if ("$ENV{CPPUNIT_FQ_DIR}")
+  if(EXISTS "$ENV{CPPUNIT_FQ_DIR}/lib/pkgconfig/cppunit.pc")
+    # Older cppunit UPS table files added the wrong directory to PKG_CONFIG_PATH.
+    set(ENV{PKG_CONFIG_PATH} "$ENV{CPPUNIT_FQ_DIR}/lib/pkgconfig:$ENV{PKG_CONFIG_PATH}")
+  endif()
 endif()
 set(_cet_findcppunit_required ${${CMAKE_FIND_PACKAGE_NAME}_FIND_REQUIRED})
 set(${CMAKE_FIND_PACKAGE_NAME}_FIND_REQUIRED)


### PR DESCRIPTION
In Spack builds, was giving:
CMake Error at /scratch/supercalifragilisticexpialidocious_extra_padding_directory/cetmodules/2.16.02/linux-scientific7-x86_64-gcc-9.3.0-efgr3lefvtp7ov743itbkatnmudqw3sx/Modules/FindCppUnit.cmake:9 (if):
  if given arguments:

    "AND" "EXISTS" "/lib/pkgconfig/cppunit.pc"

  Unknown arguments specified