### PR TITLE
Robustness: account for unset `CACHE` entry in `install_perllib()`

### DIFF
--- a/Modules/InstallPerllib.cmake
+++ b/Modules/InstallPerllib.cmake
@@ -36,7 +36,7 @@ function(install_perllib)
   project_variable(PERLLIB_DIR perllib CONFIG NO_WARN_DUPLICATE
     OMIT_IF_EMPTY OMIT_IF_MISSING OMIT_IF_NULL
     DOCSTRING "Directory below prefix to install perl files")
-  if (product AND $CACHE{${product}_perllib} MATCHES "^\\\$") # Resolve placeholder.
+  if (product AND "$CACHE{${product}_perllib}" MATCHES "^\\\$") # Resolve placeholder.
     set_property(CACHE ${product}_perllib PROPERTY VALUE
       "${$CACHE{${product}_perllib}}")
   endif()


### PR DESCRIPTION
In the current code, building cetlib@develop with Spack,  without this patch, I get:

 >> 30    CMake Error at /build/mengel/art_ci/build/subspack/cetmodules/2.31.0
           0/linux-scientific7-x86_64-gcc-9.3.0-uc7u5wqbf5vjdgrbvhvx3fohjdvk7b4
           2/Modules/InstallPerllib.cmake:39 (if):
     31      if given arguments:
     32    
     33        "product" "AND" "MATCHES" "^\\\$"
     34    
     35      Unknown arguments specified

