### PR TITLE
Extend format-code to support individual files in git repository

### DIFF
--- a/bin/.perlcriticrc
+++ b/bin/.perlcriticrc
@@ -1,0 +1,3 @@
+[-Documentation::RequirePodSections]
+[-ErrorHandling::RequireCarping]
+[-Modules::RequireVersionVar]

--- a/bin/.perlcriticrc
+++ b/bin/.perlcriticrc
@@ -1,3 +1,4 @@
 [-Documentation::RequirePodSections]
 [-ErrorHandling::RequireCarping]
+[-Modules::ProhibitExcessMainComplexity]
 [-Modules::RequireVersionVar]

--- a/bin/format-code
+++ b/bin/format-code
@@ -2,17 +2,17 @@
 
 use strict;
 use vars qw($clang_version $clang_ups_version @cpp_extensions @ignored_files);
-use Cwd qw(cwd getcwd abs_path);
+use Cwd  qw(cwd getcwd abs_path);
 use Getopt::Long qw(:config no_ignore_case bundling);
+
 
 BEGIN {
   $clang_version     = "7.0.0";
   $clang_ups_version = $clang_version =~ s/(\d+)\.(\d+)\.(\d+)/v$1_$2_$3/rg;
   @cpp_extensions    = qw(.c .cxx .cc .cpp .C .h .hxx .hh .hpp .[it]cc .H);
   @ignored_files     = qw(.svn .git CVS);
-}
-my $script_name =
-  $0 =~ s|.*/([^/]+)|$1|rg;    # Trims leading directories of script name
+} ## end BEGIN
+my $script_name = $0 =~ s|.*/([^/]+)|$1|rg; # Trims leading directories of script name
 my $directory;
 my $list_changed;
 my $verbose;
@@ -23,29 +23,31 @@ GetOptions(
   "directory|d=s"  => \$directory,
   "list-changed|l" => \$list_changed,
   "verbose|v"      => \$verbose,
-  "use-available"  => \$use_available
-) or die_while_processing_options();
+  "use-available"  => \$use_available)
+  or die_while_processing_options();
 
-if ( defined $verbose && defined $list_changed ) {
+if (defined $verbose && defined $list_changed) {
   print
 "\nERROR: Cannot specify both the 'list-changed|l' and 'verbose|v' program options.\n\n";
   exit 1;
-}
+} ## end if (defined $verbose &&...)
 
-if ( !defined $directory && !scalar @ARGV ) {
+if (!defined $directory && !scalar @ARGV) {
   print qq(
 ERROR: Either the 'directory|d' command-line option must be specified,
        or a list of files must be specified.\n);
   usage();
   exit 1;
-} ## end if (!defined $directory)
+} ## end if (!defined $directory...)
+
 
 sub usage {
   print qq(
 Usage:
   1. $script_name [-c|-n] [-v] [--use-available] -d <directory>.
   2. $script_name [-c|-n] [-v] [--use-available] file1 file2 ...\n\n);
-}
+} ## end sub usage
+
 
 sub help_message {
   print qq|
@@ -65,39 +67,44 @@ It performs the following steps:
   exit;
 } ## end sub help_message
 
+
 sub die_while_processing_options {
   usage();
   print "Type '$script_name --help' for more information.\n";
   exit 1;
 } ## end sub die_while_processing_options
 
+
 sub check_for_clean_working_area {
   my $dir = shift;
 
   # We would prefer to use git -C $directory, but older versions of git do not
   # support the -C option.
-  unless ( system("cd $dir; git diff --exit-code > /dev/null 2>&1") == 0 ) {
-    if ( !$list_changed ) {
+  unless (system("cd $dir; git diff --exit-code > /dev/null 2>&1") == 0) {
+    if (!$list_changed) {
       print q(
 Warning: Current working area has uncommitted changes.
          It may be difficult to distinguish between changes made
          by the code formatter and any uncommitted changes.\n\n);
-    }
-  } ## end unless (system(...))
+    } ## end if (!$list_changed)
+  } ## end unless (system("cd $dir; git diff --exit-code > /dev/null 2>&1"...))
 } ## end sub check_for_clean_working_area
+
 
 sub find_files {
   my $dir       = shift;
-  my $to_ignore = join( " -o ", map { "-name $_" } @ignored_files );
-  my $to_select = join( " -o ", map { "-name '*$_'" } @cpp_extensions );
+  my $to_ignore = join(" -o ", map {"-name $_"} @ignored_files);
+  my $to_select = join(" -o ", map {"-name '*$_'"} @cpp_extensions);
   my $cpp_files_str =
 `find -L $dir \\( \\( $to_ignore \\) -prune \\) -o \\( $to_select \\) -printf "%p "`;
   return $cpp_files_str;
 } ## end sub find_files
 
+
 sub line_matcher {
-  my ( $pattern, $replacement, $files ) = @_;
-  foreach my $filename ( @{$files} ) {
+  my ($pattern, $replacement, $files) = @_;
+
+  foreach my $filename (@{$files}) {
     chomp($filename);
     my $tmp_filename = $filename . ".tmp";
     open my $in,  '<',  $filename     || die "open $filename: $!";
@@ -109,49 +116,56 @@ sub line_matcher {
     }
     close $in;
     close $out;
-    rename( $tmp_filename, $filename );
+    rename($tmp_filename, $filename);
 
     if ($verbose) {
       print "    $filename\n";
     }
-  }
-}
+  } ## end foreach my $filename (@{$files...})
+} ## end sub line_matcher
+
 
 sub cleanup_whitespace {
   my $files_str = shift;
 
   # Remove trailing whitespace
   my $files_with_trailing_ws_str = `grep -l '[[:space:]]\\+\$' $files_str`;
-  if ( $files_with_trailing_ws_str ne '' ) {
+
+  if ($files_with_trailing_ws_str ne '') {
     my @files_with_trailing_ws = split /^/m, $files_with_trailing_ws_str;
-    if ( !$list_changed ) {
+
+    if (!$list_changed) {
       print "=> Removing trailing whitespace from ",
         scalar @files_with_trailing_ws, " files\n";
     }
     line_matcher '\s+$', "\n", \@files_with_trailing_ws;
-  }
+  } ## end if ($files_with_trailing_ws_str...)
 
   # Check if any files need to switch to UNIX format
   my $dos_files_str = `file $files_str | grep CRLF | cut -d ':' -f 1`;
-  if ( $dos_files_str ne '' ) {
+
+  if ($dos_files_str ne '') {
     my @dos_files = split /^/m, $dos_files_str;
-    if ( !$list_changed ) {
+
+    if (!$list_changed) {
       print "=> Switching ", scalar @dos_files, " files to UNIX format\n";
     }
     line_matcher "\r", "", \@dos_files;
   } ## end if ($dos_files_str ne ...)
 } ## end sub cleanup_whitespace
 
+
 sub apply_clang_format {
-  my ( $format_program, $files_str ) = @_;
+  my ($format_program, $files_str) = @_;
+
   if ($verbose) {
     print "=> Applying clang-format $clang_version to:\n";
-    foreach ( split ' ', $files_str ) {
+
+    foreach (split ' ', $files_str) {
       print "    $_\n";
     }
-  }
-  elsif ( !$list_changed ) {
-    my $n = scalar( split ' ', $files_str );
+  } elsif (!$list_changed) {
+    my $n = scalar(split ' ', $files_str);
     print "=> Applying clang-format $clang_version to $n files\n";
   }
 
@@ -163,11 +177,12 @@ sub apply_clang_format {
   system("$format_program -i -style=file $files_str");
 } ## end sub apply_clang_format
 
+
 sub report_changed_files {
   my $dir               = shift;
   my $changed_files_str = `cd $dir; git diff --name-only`;
 
-  if ( $changed_files_str eq '' && !$list_changed ) {
+  if ($changed_files_str eq '' && !$list_changed) {
     print "No files were changed.\n";
     return;
   }
@@ -179,52 +194,50 @@ sub report_changed_files {
     foreach (@changed_files) {
       print "  $_";
     }
-  }
-  elsif ( !$list_changed ) {
+  } elsif (!$list_changed) {
     print "Changed " . scalar @changed_files . " files\n";
-  }
-  else {
+  } else {
     print $_ foreach (@changed_files);
   }
-
 } ## end sub report_changed_files
 
 # Check that we are first in a git repository
-if ( system("type git > /dev/null 2>&1") != 0 ) {
+if (system("type git > /dev/null 2>&1") != 0) {
   print "ERROR: cannot use $script_name without git.\n";
   exit 2;
 }
-
 my $repo = defined $directory ? $directory : getcwd;
-chomp( my $in_git_repository =
-    `cd $repo; git rev-parse --is-inside-work-tree 2>/dev/null` );
-if ( $in_git_repository ne "true" ) {
+chomp(my $in_git_repository =
+    `cd $repo; git rev-parse --is-inside-work-tree 2>/dev/null`);
+
+if ($in_git_repository ne "true") {
   print "ERROR: the specified directory must be within a git repository.\n";
   exit 3;
 }
 
 # Check for .clang-format file in repository
-chomp( my $git_top_level = `cd $repo; git rev-parse --show-toplevel` );
-unless ( -f "$git_top_level/.clang-format" ) {
+chomp(my $git_top_level = `cd $repo; git rev-parse --show-toplevel`);
+
+unless (-f "$git_top_level/.clang-format") {
   my $error_prefix =
     defined $directory ? "The specified directory" : "The working directory";
   print "ERROR: $error_prefix '$repo' does not have a .clang-format file.\n";
   exit 4;
 } ## end unless (-f "$git_top_level/.clang-format")
-
-my $clang_format_program   = undef;
-my $clang_format_available = system("type clang-format > /dev/null 2>&1") == 0;
-my $search_ups             = 1;
+my $clang_format_program = undef;
+my $clang_format_available =
+  system("type clang-format > /dev/null 2>&1") == 0;
+my $search_ups = 1;
 
 if ($clang_format_available) {
   $clang_format_program = "clang-format";
-  chomp( my $available_version = `clang-format --version | head -1` );
+  chomp(my $available_version = `clang-format --version | head -1`);
   $available_version =~ s/clang-format version (\d+\.\d+\.\d+).*/$1/g;
 
   if ($use_available) {
 
     # No search necessary as the available version is what is desired
-    if ( $available_version !~ $clang_version && !$list_changed ) {
+    if ($available_version !~ $clang_version && !$list_changed) {
       print qq|
 Warning: The 'use-available' option has been specified, which will use
          clang-format $available_version instead of the expected version ($clang_version).\n\n|;
@@ -233,7 +246,7 @@ Warning: The 'use-available' option has been specified, which will use
     $search_ups    = undef;
   } ## end if ($use_available)
 
-  if ( $available_version =~ $clang_version ) {
+  if ($available_version =~ $clang_version) {
 
     # No search necessary as the correct version is available
     $search_ups = undef;
@@ -247,8 +260,7 @@ if ($search_ups) {
   my $ups_available = system("type ups > /dev/null 2>&1") == 0;
 
   if ( system("type ups > /dev/null 2>&1") != 0
-    || system("ups exist clang $clang_ups_version") != 0 )
-  {
+    || system("ups exist clang $clang_ups_version") != 0) {
     print qq|
 ERROR: clang-format $clang_version is not available.  If you have a UPS
        products area, you can download a binary distribution from
@@ -257,48 +269,49 @@ ERROR: clang-format $clang_version is not available.  If you have a UPS
        Please ensure that you have set up your UPS products area.\n|;
     exit 6;
   } ## end if (system("type ups > /dev/null 2>&1"...))
-  chomp( $clang_format_program =
+  chomp($clang_format_program =
 `. \$(\${UPS_DIR}/bin/ups setup clang $clang_ups_version) && type -p clang-format`
   );
 } ## end if ($search_ups)
-
 check_for_clean_working_area($repo);
-
 my $files_str = undef;
-if ( defined $directory ) {
-  unless ( -d "$directory" ) {
+
+if (defined $directory) {
+  unless (-d "$directory") {
     print
       "Cannot access directory '$directory' from current working directory '",
       getcwd, "'\n";
     exit 7;
-  }
-  if ( !$list_changed ) {
+  } ## end unless (-d "$directory")
+
+  if (!$list_changed) {
     print "Re-formatting files in directory '$directory'\n";
   }
   $files_str = find_files($directory);
-}
-else {
+} else {
+
   # Make sure no directories are included in the program options.
   foreach (@ARGV) {
-    if ( -d $_ ) {
+    if (-d $_) {
       print qq(
 ERROR: Directory '$_' incorrectly specified.  To format an entire directory,
        use the 'directory|d' program option.\n);
       exit 8;
-    }
-    unless ( -f $_ ) {
+    } ## end if (-d $_)
+
+    unless (-f $_) {
       print
 "\nERROR: The file '$_' is not accessible from the current working directory '$repo'.\n\n";
       exit 8;
-    }
-  }
+    } ## end unless (-f $_)
+  } ## end foreach (@ARGV)
   $files_str = join ' ', @ARGV;
-}
+} ## end else [ if (defined $directory)]
 
-if ( $files_str =~ /^\s*$/ && !$list_changed ) {
+if ($files_str =~ /^\s*$/ && !$list_changed) {
   print "No files were changed.\n";
   exit;
 }
 cleanup_whitespace($files_str);
-apply_clang_format( $clang_format_program, $files_str );
+apply_clang_format($clang_format_program, $files_str);
 report_changed_files($repo);

--- a/bin/format-code
+++ b/bin/format-code
@@ -52,6 +52,7 @@ sub usage {
 Usage:
   1. $script_name [-c|-n] [-v] [--use-available] -d <directory>.
   2. $script_name [-c|-n] [-v] [--use-available] file1 file2 ...\n\n);
+  return;
 } ## end sub usage
 
 
@@ -94,6 +95,7 @@ Warning: Current working area has uncommitted changes.
          by the code formatter and any uncommitted changes.\n\n);
     } ## end if (!$list_changed)
   } ## end unless (system("cd $dir; git diff --exit-code > /dev/null 2>&1"...))
+  return;
 } ## end sub check_for_clean_working_area
 
 
@@ -129,6 +131,7 @@ sub line_matcher {
       print "    $filename\n";
     }
   } ## end foreach my $filename (@{$files...})
+  return;
 } ## end sub line_matcher
 
 
@@ -159,6 +162,7 @@ sub cleanup_whitespace {
     }
     line_matcher "\r", "", \@dos_files;
   } ## end if ($dos_files_str ne ...)
+  return;
 } ## end sub cleanup_whitespace
 
 
@@ -181,7 +185,7 @@ sub apply_clang_format {
   # directory is inside of a git repository and (2) that the top-level
   # directory of the git repository contains a .clang-format file, we
   # are guaranteed to use the correct style file.
-  system("$format_program -i -style=file $files_str");
+  return system("$format_program -i -style=file $files_str") == 0;
 } ## end sub apply_clang_format
 
 
@@ -206,6 +210,7 @@ sub report_changed_files {
   } else {
     print $_ foreach (@changed_files);
   }
+  return;
 } ## end sub report_changed_files
 
 # Check that we are first in a git repository

--- a/bin/format-code
+++ b/bin/format-code
@@ -1,31 +1,32 @@
 #!/usr/bin/env perl
 # -*- cperl -*-
-## no critic qw(InputOutput::ProhibitBacktickOperators)
-
+## no critic qw(InputOutput::ProhibitBacktickOperators ValuesAndExpressions::ProhibitMagicNumbers)
 ##
 use strict;
 use warnings;
 
 ##
 my ($clang_version, $clang_ups_version, @cpp_extensions, @ignored_files);
-use Cwd  qw(cwd getcwd abs_path);
+
+use Cwd          qw(cwd getcwd abs_path);
+use English      qw(-no_match_vars);
 use Getopt::Long qw(:config no_ignore_case bundling);
 use IO::File     qw();
 use IO::Handle   qw();
 
 
 BEGIN {
-  $clang_version     = "7.0.0";
-  $clang_ups_version = $clang_version =~ s/(\d+)\.(\d+)\.(\d+)/v$1_$2_$3/rgmsx;
-  @cpp_extensions    = qw(.c .cxx .cc .cpp .C .h .hxx .hh .hpp .[it]cc .H);
-  @ignored_files     = qw(.svn .git CVS);
+  $clang_version = "7.0.0";
+  $clang_ups_version =
+    $clang_version =~ s/(\d+)\.(\d+)\.(\d+)/v$1_$2_$3/rgmsx;
+  @cpp_extensions = qw(.c .cxx .cc .cpp .C .h .hxx .hh .hpp .[it]cc .H);
+  @ignored_files  = qw(.svn .git CVS);
 } ## end BEGIN
-my $script_name = $0 =~ s|.*/([^/]+)|$1|rgmsx; # Trims leading directories of script name
+my $script_name = $PROGRAM_NAME =~ s|.*/([^/]+)|$1|rgmsx; # Trims leading directories of script name
 my $directory;
 my $list_changed;
 my $verbose;
 my $use_available;
-
 GetOptions(
   "help|h|?"       => \&help_message,
   "directory|d=s"  => \$directory,
@@ -96,16 +97,15 @@ sub check_for_clean_working_area {
 
   # We would prefer to use git -C $directory, but older versions of git do not
   # support the -C option.
-  unless (system("cd $dir; git diff --exit-code > /dev/null 2>&1") == 0) {
-    if (!$list_changed) {
-      print <<"EOF";
+  system("cd $dir; git diff --exit-code > /dev/null 2>&1") == 0
+    or $list_changed
+    or print <<"EOF";
+
 Warning: Current working area has uncommitted changes.
          It may be difficult to distinguish between changes made
          by the code formatter and any uncommitted changes.
 
 EOF
-    } ## end if (!$list_changed)
-  } ## end unless (system("cd $dir; git diff --exit-code > /dev/null 2>&1"...))
   return;
 } ## end sub check_for_clean_working_area
 
@@ -126,16 +126,16 @@ sub line_matcher {
   foreach my $filename (@{$files}) {
     chomp($filename);
     my $tmp_filename = $filename . ".tmp";
-    my $in           = IO::File->new("$filename") or die "open $filename: $!";
-    my $out          = IO::File->new(">>$tmp_filename")
-      or die "open $filename.tmp: $!";
+    my $in  = IO::File->new("$filename") or die "open $filename: $OS_ERROR";
+    my $out = IO::File->new(">>$tmp_filename")
+      or die "open $filename.tmp: $OS_ERROR";
 
     while (<$in>) {
       s/$pattern/$replacement/msx;
       print $out $_;
     }
-    close $in;
-    close $out;
+    $in->close;
+    $out->close;
     rename($tmp_filename, $filename);
 
     if ($verbose) {
@@ -152,7 +152,7 @@ sub cleanup_whitespace {
   # Remove trailing whitespace
   my $files_with_trailing_ws_str = `grep -l '[[:space:]]\\+\$' $files_str`;
 
-  if ($files_with_trailing_ws_str ne '') {
+  if ($files_with_trailing_ws_str ne q()) {
     my @files_with_trailing_ws = split /^/msx, $files_with_trailing_ws_str;
 
     if (!$list_changed) {
@@ -165,13 +165,13 @@ sub cleanup_whitespace {
   # Check if any files need to switch to UNIX format
   my $dos_files_str = `file $files_str | grep CRLF | cut -d ':' -f 1`;
 
-  if ($dos_files_str ne '') {
+  if ($dos_files_str ne q()) {
     my @dos_files = split /^/msx, $dos_files_str;
 
     if (!$list_changed) {
       print "=> Switching ", scalar @dos_files, " files to UNIX format\n";
     }
-    line_matcher qr&\r&msx, "", \@dos_files;
+    line_matcher qr&\r&msx, q(), \@dos_files;
   } ## end if ($dos_files_str ne ...)
   return;
 } ## end sub cleanup_whitespace
@@ -183,11 +183,11 @@ sub apply_clang_format {
   if ($verbose) {
     print "=> Applying clang-format $clang_version to:\n";
 
-    foreach (split ' ', $files_str) {
-      print "    $_\n";
+    foreach (split q( ), $files_str) {
+      print qq(    $_\n);
     }
   } elsif (!$list_changed) {
-    my $n = scalar(split ' ', $files_str);
+    my $n = scalar(split q( ), $files_str);
     print "=> Applying clang-format $clang_version to $n files\n";
   }
 
@@ -204,7 +204,7 @@ sub report_changed_files {
   my $dir               = shift;
   my $changed_files_str = `cd $dir; git diff --name-only`;
 
-  if ($changed_files_str eq '' && !$list_changed) {
+  if ($changed_files_str eq q() && !$list_changed) {
     print "No files were changed.\n";
     return;
   }
@@ -219,8 +219,10 @@ sub report_changed_files {
   } elsif (!$list_changed) {
     print "Changed " . scalar @changed_files . " files\n";
   } else {
-    print $_ foreach (@changed_files);
-  }
+    foreach (@changed_files) {
+      print;
+    }
+  } ## end else [ if ($verbose)  [elsif (!$list_changed) ]]
   return;
 } ## end sub report_changed_files
 
@@ -241,12 +243,12 @@ if ($in_git_repository ne "true") {
 # Check for .clang-format file in repository
 chomp(my $git_top_level = `cd $repo; git rev-parse --show-toplevel`);
 
-unless (-f "$git_top_level/.clang-format") {
+if (not -f "$git_top_level/.clang-format") {
   my $error_prefix =
     defined $directory ? "The specified directory" : "The working directory";
   print "ERROR: $error_prefix '$repo' does not have a .clang-format file.\n";
   exit 4;
-} ## end unless (-f "$git_top_level/.clang-format")
+} ## end if (not -f "$git_top_level/.clang-format")
 my $clang_format_program = undef;
 my $clang_format_available =
   system("type clang-format > /dev/null 2>&1") == 0;
@@ -303,12 +305,12 @@ check_for_clean_working_area($repo);
 my $files_str = undef;
 
 if (defined $directory) {
-  unless (-d "$directory") {
+  if (not -d "$directory") {
     print
       "Cannot access directory '$directory' from current working directory '",
       getcwd, "'\n";
     exit 7;
-  } ## end unless (-d "$directory")
+  } ## end if (not -d "$directory")
 
   if (!$list_changed) {
     print "Re-formatting files in directory '$directory'\n";
@@ -318,21 +320,21 @@ if (defined $directory) {
 
   # Make sure no directories are included in the program options.
   foreach (@ARGV) {
-    if (-d $_) {
+    if (-d) {
       print <<"EOF";
 ERROR: Directory '$_' incorrectly specified.  To format an entire directory,
        use the 'directory|d' program option.
 EOF
       exit 8;
-    } ## end if (-d $_)
+    } ## end if (-d)
 
-    unless (-f $_) {
+    if (not -f) {
       print
 "\nERROR: The file '$_' is not accessible from the current working directory '$repo'.\n\n";
       exit 8;
-    } ## end unless (-f $_)
+    } ## end if (not -f)
   } ## end foreach (@ARGV)
-  $files_str = join ' ', @ARGV;
+  $files_str = join q( ), @ARGV;
 } ## end else [ if (defined $directory)]
 
 if ($files_str =~ /\A\s*\Z/msx && !$list_changed) {

--- a/bin/format-code
+++ b/bin/format-code
@@ -8,6 +8,8 @@ use warnings;
 use vars qw($clang_version $clang_ups_version @cpp_extensions @ignored_files);
 use Cwd  qw(cwd getcwd abs_path);
 use Getopt::Long qw(:config no_ignore_case bundling);
+use IO::File     qw();
+use IO::Handle   qw();
 
 
 BEGIN {
@@ -111,8 +113,9 @@ sub line_matcher {
   foreach my $filename (@{$files}) {
     chomp($filename);
     my $tmp_filename = $filename . ".tmp";
-    open my $in,  '<',  $filename     || die "open $filename: $!";
-    open my $out, '>>', $tmp_filename || die "open $filename.tmp: $!";
+    my $in           = IO::File->new("$filename") or die "open $filename: $!";
+    my $out          = IO::File->new(">>$tmp_filename")
+      or die "open $filename.tmp: $!";
 
     while (<$in>) {
       s/$pattern/$replacement/;

--- a/bin/format-code
+++ b/bin/format-code
@@ -1,18 +1,18 @@
 #!/usr/bin/perl -w
 
 use strict;
-use vars qw($clang_version);
-use vars qw($clang_ups_version);
+use vars qw($clang_version $clang_ups_version @cpp_extensions @ignored_files);
 use Cwd qw(cwd getcwd abs_path);
 use Getopt::Long qw(:config no_ignore_case bundling);
-
 
 BEGIN {
   $clang_version     = "7.0.0";
   $clang_ups_version = $clang_version =~ s/(\d+)\.(\d+)\.(\d+)/v$1_$2_$3/rg;
+  @cpp_extensions    = qw(.c .cxx .cc .cpp .C .h .hxx .hh .hpp .[it]cc .H);
+  @ignored_files     = qw(.svn .git CVS);
 }
-my $script_name = $0 =~ s|.*/([^/]+)|$1|rg; # Trims leading directories of script name
-my $commit;
+my $script_name =
+  $0 =~ s|.*/([^/]+)|$1|rg;    # Trims leading directories of script name
 my $directory;
 my $verbose;
 my $use_available;
@@ -20,48 +20,41 @@ my $dry_run;
 GetOptions(
   "help|h|?"      => \&help_message,
   "directory|d=s" => \$directory,
-  "commit|c"      => \$commit,
-  "dry-run|n"     => \$dry_run,
   "verbose|v"     => \$verbose,
-  "use-available" => \$use_available)
-  or die_while_processing_options();
+  "use-available" => \$use_available
+) or die_while_processing_options();
 
-if (!defined $directory) {
-  print "The 'directory|d' command-line option is required:\n";
+if ( !defined $directory && !scalar @ARGV ) {
+  print qq(
+ERROR: Either the 'directory|d' command-line option must be specified,
+       or a list of files must be specified.\n);
   usage();
   exit 1;
 } ## end if (!defined $directory)
 
-if (defined $dry_run) {
-  print "The 'dry-run' option is not yet supported.\n";
-  exit 1;
-}
-
-
 sub usage {
-  print "Usage: $script_name -d <directory> [-c|-n] [-v] [--use-available]\n";
+  print qq(
+Usage:
+  1. $script_name [-c|-n] [-v] [--use-available] -d <directory>.
+  2. $script_name [-c|-n] [-v] [--use-available] file1 file2 ...\n\n);
 }
-
 
 sub help_message {
+  print qq|
+$script_name automatically formats C++ code that resides in a Git repository.
+It performs the following steps:
+
+  - Removal of trailing whitespaces
+  - DOS-to-UNIX file format conversions
+  - clang-format (requires .clang-format file in top directory of repository)\n|;
   usage();
-  print "Options:\n";
-  print
-"  -d [--directory] arg   Top-level directory to apply formatting script.\n";
-  print
-"  -c [--commit]          Commit changes after code-formatting has been applied.\n";
-  print
-"                         To use the 'commit' option, you must have a clean working\n";
-  print "                         area before invoking this script.\n";
-  print "  -n [--dry-run]         No changes will be made.\n";
-  print "  -v [--verbose]\n";
-  print
-"  --use-available        Use the version of clang-format already set up for use.\n";
-  print
-"                         This option can be used to override clang-format $clang_version.\n";
+  print qq(Options:
+  -d [--directory] arg   Top-level directory to apply formatting script.
+  -v [--verbose]         Print the name of each adjusted file.
+  --use-available        Use the version of clang-format already set up for use.
+                         This option can be used to override clang-format $clang_version.\n\n);
   exit;
 } ## end sub help_message
-
 
 sub die_while_processing_options {
   usage();
@@ -69,73 +62,83 @@ sub die_while_processing_options {
   exit 1;
 } ## end sub die_while_processing_options
 
-
 sub check_for_clean_working_area {
+  my $dir = shift;
 
   # We would prefer to use git -C $directory, but older versions of git do not
   # support the -C option.
-  unless (system("cd $directory; git diff --exit-code > /dev/null 2>&1") == 0)
-  {
-    if ($commit) {
-      print "Error: The following working area has uncommitted changes:\n";
-      print "         '" . abs_path($directory) . "'\n";
-      print "       Please commit them before running $script_name with\n";
-      print "       the 'commit|c' program option.\n";
-      exit 2;
-    } ## end if ($commit)
-    print "\nWarning: Current working area has uncommitted changes.\n";
-    print
-      "         It may be difficult to distinguish between changes made\n";
-    print "         by the code formatter and any uncommitted changes.\n\n";
+  unless ( system("cd $dir; git diff --exit-code > /dev/null 2>&1") == 0 ) {
+    print q(
+Warning: Current working area has uncommitted changes.
+         It may be difficult to distinguish between changes made
+         by the code formatter and any uncommitted changes.\n\n);
   } ## end unless (system(...))
 } ## end sub check_for_clean_working_area
 
-
 sub find_files {
+  my $dir       = shift;
+  my $to_ignore = join( " -o ", map { "-name $_" } @ignored_files );
+  my $to_select = join( " -o ", map { "-name '*$_'" } @cpp_extensions );
   my $cpp_files_str =
-`find -L $directory \\( \\( -name .svn -o -name .git -o -name CVS \\) -prune \\) -o \\( -name '*.c' -o -name '*.cxx' -o -name '*.cc' -o -name '*.cpp' -o -name '*.C' -o -name '*.h' -o -name '*.hxx' -o -name '*.hh' -o -name '*.hpp' -o -name '*.[it]cc' -o -name '*.H*' \\) -printf "%p "`;
+`find -L $dir \\( \\( $to_ignore \\) -prune \\) -o \\( $to_select \\) -printf "%p "`;
   return $cpp_files_str;
 } ## end sub find_files
 
+sub line_matcher {
+  my ( $pattern, $replacement, $files ) = @_;
+  foreach my $filename ( @{$files} ) {
+    chomp($filename);
+    my $tmp_filename = $filename . ".tmp";
+    open my $in,  '<',  $filename     || die "open $filename: $!";
+    open my $out, '>>', $tmp_filename || die "open $filename.tmp: $!";
+
+    while (<$in>) {
+      s/$pattern/$replacement/;
+      print $out $_;
+    }
+    close $in;
+    close $out;
+    rename( $tmp_filename, $filename );
+
+    if ($verbose) {
+      print "    $filename\n";
+    }
+  }
+}
 
 sub cleanup_whitespace {
   my $files_str = shift;
 
+  # Remove trailing whitespace
+  my $files_with_trailing_ws_str = `grep -l '[[:space:]]\\+\$' $files_str`;
+  if ( $files_with_trailing_ws_str ne '' ) {
+    my @files_with_trailing_ws = split /^/m, $files_with_trailing_ws_str;
+    print "=> Removing trailing whitespace from ",
+      scalar @files_with_trailing_ws, " files\n";
+    line_matcher '\s+$', "\n", \@files_with_trailing_ws;
+  }
+
   # Check if any files need to switch to UNIX format
   my $dos_files_str = `file $files_str | grep CRLF | cut -d ':' -f 1`;
-
-  if ($dos_files_str ne '') {
+  if ( $dos_files_str ne '' ) {
     my @dos_files = split /^/m, $dos_files_str;
-    print "  Switching ", scalar @dos_files, " files to UNIX format\n";
-
-    foreach (@dos_files) {
-      chomp(my $filename = $_);
-      my $tmp_filename = $filename . ".tmp";
-      open my $in,  '<',  $filename     || die "open $filename: $!";
-      open my $out, '>>', $tmp_filename || die "open $filename.tmp: $!";
-
-      while (<$in>) {
-        s/\r//g;
-        print $out $_;
-      }
-      close $in;
-      close $out;
-      rename($tmp_filename, $filename);
-
-      if ($verbose) {
-        print "    Changed file: " . $filename . "\n";
-      }
-    } ## end foreach (@dos_files)
+    print "=> Switching ", scalar @dos_files, " files to UNIX format\n";
+    line_matcher "\r", "", \@dos_files;
   } ## end if ($dos_files_str ne ...)
 } ## end sub cleanup_whitespace
 
-
 sub apply_clang_format {
-
-  # clang-format removes trailing whitespace errors, so we do not
-  # worry about those.
-  my ($format_program, $files_str) = @_;
-  print "  Applying clang-format $clang_version\n";
+  my ( $format_program, $files_str ) = @_;
+  if ($verbose) {
+    print "=> Applying clang-format $clang_version to:\n";
+    foreach ( split ' ', $files_str ) {
+      print "    $_\n";
+    }
+  }
+  else {
+    my $n = scalar( split ' ', $files_str );
+    print "=> Applying clang-format $clang_version to $n files\n";
+  }
 
   # clang-format will use the style file located in a parent directory
   # of the specified directory.  Because we require that (1) the
@@ -145,11 +148,11 @@ sub apply_clang_format {
   system("$format_program -i -style=file $files_str");
 } ## end sub apply_clang_format
 
-
 sub report_changed_files {
-  my $changed_files_str = `cd $directory; git diff --name-only`;
+  my $dir               = shift;
+  my $changed_files_str = `cd $dir; git diff --name-only`;
 
-  if ($changed_files_str eq '') {
+  if ( $changed_files_str eq '' ) {
     print "No files were changed.\n";
     return;
   }
@@ -161,69 +164,58 @@ sub report_changed_files {
     foreach (@changed_files) {
       print "  $_";
     }
-  } else {
-    print "Changed " . scalar(@changed_files) . " files\n";
+  }
+  else {
+    print "Changed " . scalar @changed_files . " files\n";
   }
 
-  if ($commit) {
-    system(
-"cd $directory; git add .; git commit -m 'Apply clang-format $clang_version.'"
-    );
-  } ## end if ($commit)
 } ## end sub report_changed_files
 
-unless (-d "$directory") {
-  print
-    "Cannot access directory '$directory' from current working directory '",
-    getcwd, "'\n";
-  exit 3;
-} ## end unless (-d "$directory")
-
 # Check that we are first in a git repository
-if (system("type git > /dev/null 2>&1") != 0) {
-  print "Error: cannot use $script_name without git.\n";
+if ( system("type git > /dev/null 2>&1") != 0 ) {
+  print "ERROR: cannot use $script_name without git.\n";
   exit 2;
 }
-chomp(my $in_git_repository =
-    `cd $directory; git rev-parse --is-inside-work-tree 2>/dev/null`);
 
-if ($in_git_repository ne "true") {
-  print "Error: the specified directory must be within a git repository.\n";
-  exit 4;
+my $repo = defined $directory ? $directory : getcwd;
+chomp( my $in_git_repository =
+    `cd $repo; git rev-parse --is-inside-work-tree 2>/dev/null` );
+if ( $in_git_repository ne "true" ) {
+  print "ERROR: the specified directory must be within a git repository.\n";
+  exit 3;
 }
 
 # Check for .clang-format file in repository
-chomp(my $git_top_level = `cd $directory; git rev-parse --show-toplevel`);
-
-unless (-f "$git_top_level/.clang-format") {
-  print
-    "Error: the specified repository does not have a .clang-format file.\n";
-  exit 5;
+chomp( my $git_top_level = `cd $repo; git rev-parse --show-toplevel` );
+unless ( -f "$git_top_level/.clang-format" ) {
+  my $error_prefix =
+    defined $directory ? "The specified directory" : "The working directory";
+  print "ERROR: $error_prefix '$repo' does not have a .clang-format file.\n";
+  exit 4;
 } ## end unless (-f "$git_top_level/.clang-format")
-my $clang_format_program;
-my $clang_format_available =
-  system("type clang-format > /dev/null 2>&1") == 0;
-my $search_ups = 1;
+
+my $clang_format_program   = undef;
+my $clang_format_available = system("type clang-format > /dev/null 2>&1") == 0;
+my $search_ups             = 1;
 
 if ($clang_format_available) {
   $clang_format_program = "clang-format";
-  chomp(my $available_version = `clang-format --version | head -1`);
+  chomp( my $available_version = `clang-format --version | head -1` );
   $available_version =~ s/clang-format version (\d+\.\d+\.\d+).*/$1/g;
 
   if ($use_available) {
 
     # No search necessary as the available version is what is desired
-    if ($available_version !~ $clang_version) {
-      print
-"\nWarning: The 'use-available' option has been specified, which will use\n";
-      print
-"         clang-format $available_version instead of the expected version ($clang_version).\n\n";
+    if ( $available_version !~ $clang_version ) {
+      print qq|
+Warning: The 'use-available' option has been specified, which will use
+         clang-format $available_version instead of the expected version ($clang_version).\n\n|;
     } ## end if ($available_version...)
     $clang_version = $available_version;
     $search_ups    = undef;
   } ## end if ($use_available)
 
-  if ($available_version =~ $clang_version) {
+  if ( $available_version =~ $clang_version ) {
 
     # No search necessary as the correct version is available
     $search_ups = undef;
@@ -237,29 +229,56 @@ if ($search_ups) {
   my $ups_available = system("type ups > /dev/null 2>&1") == 0;
 
   if ( system("type ups > /dev/null 2>&1") != 0
-    || system("ups exist clang $clang_ups_version") != 0) {
-    print
-"Error: clang-format $clang_version is not available.  If you have a UPS\n";
-    print
-      "       products area, you can download a binary distribution from\n";
-    print
-"       https://scisoft.fnal.gov/scisoft/packages/clang/$clang_ups_version\n";
-    print
-      "       Please ensure that you have set up your UPS products area.\n";
-    exit 7;
+    || system("ups exist clang $clang_ups_version") != 0 )
+  {
+    print qq|
+ERROR: clang-format $clang_version is not available.  If you have a UPS
+       products area, you can download a binary distribution from
+       https://scisoft.fnal.gov/scisoft/packages/clang/$clang_ups_version
+
+       Please ensure that you have set up your UPS products area.\n|;
+    exit 6;
   } ## end if (system("type ups > /dev/null 2>&1"...))
-  chomp($clang_format_program =
+  chomp( $clang_format_program =
 `. \$(\${UPS_DIR}/bin/ups setup clang $clang_ups_version) && type -p clang-format`
   );
 } ## end if ($search_ups)
-check_for_clean_working_area();
-print "Re-formatting files in directory '" . abs_path($directory) . "'\n";
-my $files_str = find_files();
 
-if ($files_str =~ /^\s*$/) {
+check_for_clean_working_area($repo);
+
+my $files_str = undef;
+if ( defined $directory ) {
+  unless ( -d "$directory" ) {
+    print
+      "Cannot access directory '$directory' from current working directory '",
+      getcwd, "'\n";
+    exit 7;
+  }
+  print "Re-formatting files in directory '$directory'\n";
+  $files_str = find_files($directory);
+}
+else {
+  # Make sure no directories are included in the program options.
+  foreach (@ARGV) {
+    if ( -d $_ ) {
+      print qq(
+ERROR: Directory '$_' incorrectly specified.  To format an entire directory,
+       use the 'directory|d' program option.\n);
+      exit 8;
+    }
+    unless ( -f $_ ) {
+      print
+"\nERROR: The file '$_' is not accessible from the current working directory '$repo'.\n\n";
+      exit 8;
+    }
+  }
+  $files_str = join ' ', @ARGV;
+}
+
+if ( $files_str =~ /^\s*$/ ) {
   print "No files were changed.\n";
   exit;
 }
 cleanup_whitespace($files_str);
-apply_clang_format($clang_format_program, $files_str);
-report_changed_files();
+apply_clang_format( $clang_format_program, $files_str );
+report_changed_files($repo);

--- a/bin/format-code
+++ b/bin/format-code
@@ -1,6 +1,10 @@
-#!/usr/bin/perl -w
+#!/usr/bin/env perl
+# -*- cperl -*-
 
 use strict;
+use warnings;
+
+##
 use vars qw($clang_version $clang_ups_version @cpp_extensions @ignored_files);
 use Cwd  qw(cwd getcwd abs_path);
 use Getopt::Long qw(:config no_ignore_case bundling);

--- a/bin/format-code
+++ b/bin/format-code
@@ -14,15 +14,23 @@ BEGIN {
 my $script_name =
   $0 =~ s|.*/([^/]+)|$1|rg;    # Trims leading directories of script name
 my $directory;
+my $list_changed;
 my $verbose;
 my $use_available;
 my $dry_run;
 GetOptions(
-  "help|h|?"      => \&help_message,
-  "directory|d=s" => \$directory,
-  "verbose|v"     => \$verbose,
-  "use-available" => \$use_available
+  "help|h|?"       => \&help_message,
+  "directory|d=s"  => \$directory,
+  "list-changed|l" => \$list_changed,
+  "verbose|v"      => \$verbose,
+  "use-available"  => \$use_available
 ) or die_while_processing_options();
+
+if ( defined $verbose && defined $list_changed ) {
+  print
+"\nERROR: Cannot specify both the 'list-changed|l' and 'verbose|v' program options.\n\n";
+  exit 1;
+}
 
 if ( !defined $directory && !scalar @ARGV ) {
   print qq(
@@ -48,11 +56,12 @@ It performs the following steps:
   - DOS-to-UNIX file format conversions
   - clang-format (requires .clang-format file in top directory of repository)\n|;
   usage();
-  print qq(Options:
+  print qq|Options:
   -d [--directory] arg   Top-level directory to apply formatting script.
+  -l [--list-changed]    Only print the names of changed files (no informational messages).
   -v [--verbose]         Print the name of each adjusted file.
   --use-available        Use the version of clang-format already set up for use.
-                         This option can be used to override clang-format $clang_version.\n\n);
+                         This option can be used to override clang-format $clang_version.\n\n|;
   exit;
 } ## end sub help_message
 
@@ -68,10 +77,12 @@ sub check_for_clean_working_area {
   # We would prefer to use git -C $directory, but older versions of git do not
   # support the -C option.
   unless ( system("cd $dir; git diff --exit-code > /dev/null 2>&1") == 0 ) {
-    print q(
+    if ( !$list_changed ) {
+      print q(
 Warning: Current working area has uncommitted changes.
          It may be difficult to distinguish between changes made
          by the code formatter and any uncommitted changes.\n\n);
+    }
   } ## end unless (system(...))
 } ## end sub check_for_clean_working_area
 
@@ -113,8 +124,10 @@ sub cleanup_whitespace {
   my $files_with_trailing_ws_str = `grep -l '[[:space:]]\\+\$' $files_str`;
   if ( $files_with_trailing_ws_str ne '' ) {
     my @files_with_trailing_ws = split /^/m, $files_with_trailing_ws_str;
-    print "=> Removing trailing whitespace from ",
-      scalar @files_with_trailing_ws, " files\n";
+    if ( !$list_changed ) {
+      print "=> Removing trailing whitespace from ",
+        scalar @files_with_trailing_ws, " files\n";
+    }
     line_matcher '\s+$', "\n", \@files_with_trailing_ws;
   }
 
@@ -122,7 +135,9 @@ sub cleanup_whitespace {
   my $dos_files_str = `file $files_str | grep CRLF | cut -d ':' -f 1`;
   if ( $dos_files_str ne '' ) {
     my @dos_files = split /^/m, $dos_files_str;
-    print "=> Switching ", scalar @dos_files, " files to UNIX format\n";
+    if ( !$list_changed ) {
+      print "=> Switching ", scalar @dos_files, " files to UNIX format\n";
+    }
     line_matcher "\r", "", \@dos_files;
   } ## end if ($dos_files_str ne ...)
 } ## end sub cleanup_whitespace
@@ -135,7 +150,7 @@ sub apply_clang_format {
       print "    $_\n";
     }
   }
-  else {
+  elsif ( !$list_changed ) {
     my $n = scalar( split ' ', $files_str );
     print "=> Applying clang-format $clang_version to $n files\n";
   }
@@ -152,7 +167,7 @@ sub report_changed_files {
   my $dir               = shift;
   my $changed_files_str = `cd $dir; git diff --name-only`;
 
-  if ( $changed_files_str eq '' ) {
+  if ( $changed_files_str eq '' && !$list_changed ) {
     print "No files were changed.\n";
     return;
   }
@@ -165,8 +180,11 @@ sub report_changed_files {
       print "  $_";
     }
   }
-  else {
+  elsif ( !$list_changed ) {
     print "Changed " . scalar @changed_files . " files\n";
+  }
+  else {
+    print $_ foreach (@changed_files);
   }
 
 } ## end sub report_changed_files
@@ -206,7 +224,7 @@ if ($clang_format_available) {
   if ($use_available) {
 
     # No search necessary as the available version is what is desired
-    if ( $available_version !~ $clang_version ) {
+    if ( $available_version !~ $clang_version && !$list_changed ) {
       print qq|
 Warning: The 'use-available' option has been specified, which will use
          clang-format $available_version instead of the expected version ($clang_version).\n\n|;
@@ -254,7 +272,9 @@ if ( defined $directory ) {
       getcwd, "'\n";
     exit 7;
   }
-  print "Re-formatting files in directory '$directory'\n";
+  if ( !$list_changed ) {
+    print "Re-formatting files in directory '$directory'\n";
+  }
   $files_str = find_files($directory);
 }
 else {
@@ -275,7 +295,7 @@ ERROR: Directory '$_' incorrectly specified.  To format an entire directory,
   $files_str = join ' ', @ARGV;
 }
 
-if ( $files_str =~ /^\s*$/ ) {
+if ( $files_str =~ /^\s*$/ && !$list_changed ) {
   print "No files were changed.\n";
   exit;
 }

--- a/bin/format-code
+++ b/bin/format-code
@@ -54,8 +54,8 @@ EOF
 sub usage {
   print <<"EOF";
 Usage:
-  1. $script_name [-c|-n] [-v] [--use-available] -d <directory>.
-  2. $script_name [-c|-n] [-v] [--use-available] file1 file2 ...
+  1. $script_name [-v|-l] [--use-available] -d <directory>.
+  2. $script_name [-v|-l] [--use-available] file1 file2 ...
 
 EOF
   return;
@@ -64,12 +64,14 @@ EOF
 
 sub help_message {
   print <<"EOF";
+
 $script_name automatically formats C++ code that resides in a Git repository.
 It performs the following steps:
 
   - Removal of trailing whitespaces
   - DOS-to-UNIX file format conversions
   - clang-format (requires .clang-format file in top directory of repository)
+
 EOF
   usage();
   print <<"EOF";

--- a/bin/format-code
+++ b/bin/format-code
@@ -1,11 +1,13 @@
 #!/usr/bin/env perl
 # -*- cperl -*-
+## no critic qw(InputOutput::ProhibitBacktickOperators)
 
+##
 use strict;
 use warnings;
 
 ##
-use vars qw($clang_version $clang_ups_version @cpp_extensions @ignored_files);
+my ($clang_version, $clang_ups_version, @cpp_extensions, @ignored_files);
 use Cwd  qw(cwd getcwd abs_path);
 use Getopt::Long qw(:config no_ignore_case bundling);
 use IO::File     qw();
@@ -14,16 +16,16 @@ use IO::Handle   qw();
 
 BEGIN {
   $clang_version     = "7.0.0";
-  $clang_ups_version = $clang_version =~ s/(\d+)\.(\d+)\.(\d+)/v$1_$2_$3/rg;
+  $clang_ups_version = $clang_version =~ s/(\d+)\.(\d+)\.(\d+)/v$1_$2_$3/rgmsx;
   @cpp_extensions    = qw(.c .cxx .cc .cpp .C .h .hxx .hh .hpp .[it]cc .H);
   @ignored_files     = qw(.svn .git CVS);
 } ## end BEGIN
-my $script_name = $0 =~ s|.*/([^/]+)|$1|rg; # Trims leading directories of script name
+my $script_name = $0 =~ s|.*/([^/]+)|$1|rgmsx; # Trims leading directories of script name
 my $directory;
 my $list_changed;
 my $verbose;
 my $use_available;
-my $dry_run;
+
 GetOptions(
   "help|h|?"       => \&help_message,
   "directory|d=s"  => \$directory,
@@ -39,38 +41,45 @@ if (defined $verbose && defined $list_changed) {
 } ## end if (defined $verbose &&...)
 
 if (!defined $directory && !scalar @ARGV) {
-  print qq(
+  print <<"EOF";
 ERROR: Either the 'directory|d' command-line option must be specified,
-       or a list of files must be specified.\n);
+       or a list of files must be specified.
+EOF
   usage();
   exit 1;
 } ## end if (!defined $directory...)
 
 
 sub usage {
-  print qq(
+  print <<"EOF";
 Usage:
   1. $script_name [-c|-n] [-v] [--use-available] -d <directory>.
-  2. $script_name [-c|-n] [-v] [--use-available] file1 file2 ...\n\n);
+  2. $script_name [-c|-n] [-v] [--use-available] file1 file2 ...
+
+EOF
   return;
 } ## end sub usage
 
 
 sub help_message {
-  print qq|
+  print <<"EOF";
 $script_name automatically formats C++ code that resides in a Git repository.
 It performs the following steps:
 
   - Removal of trailing whitespaces
   - DOS-to-UNIX file format conversions
-  - clang-format (requires .clang-format file in top directory of repository)\n|;
+  - clang-format (requires .clang-format file in top directory of repository)
+EOF
   usage();
-  print qq|Options:
+  print <<"EOF";
+Options:
   -d [--directory] arg   Top-level directory to apply formatting script.
   -l [--list-changed]    Only print the names of changed files (no informational messages).
   -v [--verbose]         Print the name of each adjusted file.
   --use-available        Use the version of clang-format already set up for use.
-                         This option can be used to override clang-format $clang_version.\n\n|;
+                         This option can be used to override clang-format $clang_version.
+
+EOF
   exit;
 } ## end sub help_message
 
@@ -89,10 +98,12 @@ sub check_for_clean_working_area {
   # support the -C option.
   unless (system("cd $dir; git diff --exit-code > /dev/null 2>&1") == 0) {
     if (!$list_changed) {
-      print q(
+      print <<"EOF";
 Warning: Current working area has uncommitted changes.
          It may be difficult to distinguish between changes made
-         by the code formatter and any uncommitted changes.\n\n);
+         by the code formatter and any uncommitted changes.
+
+EOF
     } ## end if (!$list_changed)
   } ## end unless (system("cd $dir; git diff --exit-code > /dev/null 2>&1"...))
   return;
@@ -120,7 +131,7 @@ sub line_matcher {
       or die "open $filename.tmp: $!";
 
     while (<$in>) {
-      s/$pattern/$replacement/;
+      s/$pattern/$replacement/msx;
       print $out $_;
     }
     close $in;
@@ -142,25 +153,25 @@ sub cleanup_whitespace {
   my $files_with_trailing_ws_str = `grep -l '[[:space:]]\\+\$' $files_str`;
 
   if ($files_with_trailing_ws_str ne '') {
-    my @files_with_trailing_ws = split /^/m, $files_with_trailing_ws_str;
+    my @files_with_trailing_ws = split /^/msx, $files_with_trailing_ws_str;
 
     if (!$list_changed) {
       print "=> Removing trailing whitespace from ",
         scalar @files_with_trailing_ws, " files\n";
     }
-    line_matcher '\s+$', "\n", \@files_with_trailing_ws;
+    line_matcher qr&\s+\Z&msx, "\n", \@files_with_trailing_ws;
   } ## end if ($files_with_trailing_ws_str...)
 
   # Check if any files need to switch to UNIX format
   my $dos_files_str = `file $files_str | grep CRLF | cut -d ':' -f 1`;
 
   if ($dos_files_str ne '') {
-    my @dos_files = split /^/m, $dos_files_str;
+    my @dos_files = split /^/msx, $dos_files_str;
 
     if (!$list_changed) {
       print "=> Switching ", scalar @dos_files, " files to UNIX format\n";
     }
-    line_matcher "\r", "", \@dos_files;
+    line_matcher qr&\r&msx, "", \@dos_files;
   } ## end if ($dos_files_str ne ...)
   return;
 } ## end sub cleanup_whitespace
@@ -197,7 +208,7 @@ sub report_changed_files {
     print "No files were changed.\n";
     return;
   }
-  my @changed_files = split /^/m, $changed_files_str;
+  my @changed_files = split /^/msx, $changed_files_str;
 
   if ($verbose) {
     print "\nThe following files were changed:\n";
@@ -244,15 +255,17 @@ my $search_ups = 1;
 if ($clang_format_available) {
   $clang_format_program = "clang-format";
   chomp(my $available_version = `clang-format --version | head -1`);
-  $available_version =~ s/clang-format version (\d+\.\d+\.\d+).*/$1/g;
+  $available_version =~ s/clang-format version (\d+\.\d+\.\d+).*/$1/gmsx;
 
   if ($use_available) {
 
     # No search necessary as the available version is what is desired
     if ($available_version !~ $clang_version && !$list_changed) {
-      print qq|
+      print <<"EOF";
 Warning: The 'use-available' option has been specified, which will use
-         clang-format $available_version instead of the expected version ($clang_version).\n\n|;
+         clang-format $available_version instead of the expected version ($clang_version).
+
+EOF
     } ## end if ($available_version...)
     $clang_version = $available_version;
     $search_ups    = undef;
@@ -273,12 +286,13 @@ if ($search_ups) {
 
   if ( system("type ups > /dev/null 2>&1") != 0
     || system("ups exist clang $clang_ups_version") != 0) {
-    print qq|
+    print <<"EOF";
 ERROR: clang-format $clang_version is not available.  If you have a UPS
        products area, you can download a binary distribution from
        https://scisoft.fnal.gov/scisoft/packages/clang/$clang_ups_version
 
-       Please ensure that you have set up your UPS products area.\n|;
+       Please ensure that you have set up your UPS products area.
+EOF
     exit 6;
   } ## end if (system("type ups > /dev/null 2>&1"...))
   chomp($clang_format_program =
@@ -305,9 +319,10 @@ if (defined $directory) {
   # Make sure no directories are included in the program options.
   foreach (@ARGV) {
     if (-d $_) {
-      print qq(
+      print <<"EOF";
 ERROR: Directory '$_' incorrectly specified.  To format an entire directory,
-       use the 'directory|d' program option.\n);
+       use the 'directory|d' program option.
+EOF
       exit 8;
     } ## end if (-d $_)
 
@@ -320,7 +335,7 @@ ERROR: Directory '$_' incorrectly specified.  To format an entire directory,
   $files_str = join ' ', @ARGV;
 } ## end else [ if (defined $directory)]
 
-if ($files_str =~ /^\s*$/ && !$list_changed) {
+if ($files_str =~ /\A\s*\Z/msx && !$list_changed) {
   print "No files were changed.\n";
   exit;
 }

--- a/test/libexec/CMakeLists.txt
+++ b/test/libexec/CMakeLists.txt
@@ -28,6 +28,7 @@ set(PERL_FILES
   ${PROJECT_SOURCE_DIR}/libexec/Cetmodules/Migrate/ProductDeps.pm
   ${PROJECT_SOURCE_DIR}/libexec/set_dev_products
   ${PROJECT_SOURCE_DIR}/tools/migrate
+  ${PROJECT_SOURCE_DIR}/bin/format-code
   ${PERL_TEST_SCRIPTS}
   ${PROJECT_SOURCE_DIR}/test/Modules/version_cmp-cmake_t
   )


### PR DESCRIPTION
This PR makes it possible to `format-code` on individual files.  For a project LArSoft, the code-checks PR step could return a statement like:

> Pull request failed code-formatting checks.  Please ensure that `cetmodules` has been setup and execute the following command from the top-level directory of your repository:
> ```
> format-code \
>   'lardataobj/RecoBase/OpWaveform.h' \
>   'lardataobj/RecoBase/TrackTrajectory.tcc' \
>   'lardataobj/RecoBase/Trajectory.tcc' \
>   'lardataobj/RecoBase/TrajectoryPointFlags.tcc' \
>   'lardataobj/RecoBase/Wire.h' \
>   'lardataobj/Simulation/SimPhotons.h' \
>   'lardataobj/Utilities/BitMask.tcc' \
>   'lardataobj/Utilities/FlagSet.tcc'
> ```

----

### format-code -h

```console
$ format-code -h

format-code automatically formats C++ code that resides in a Git repository.
It performs the following steps:

  - Removal of trailing whitespaces
  - DOS-to-UNIX file format conversions
  - clang-format (requires .clang-format file in top directory of repository)

Usage:
  1. format-code [-c|-n] [-v] [--use-available] -d <directory>.
  2. format-code [-c|-n] [-v] [--use-available] file1 file2 ...

Options:
  -d [--directory] arg   Top-level directory to apply formatting script.
  -l [--list-changed]    Only print the names of changed files (no informational messages).
  -v [--verbose]         Print the name of each adjusted file.
  --use-available        Use the version of clang-format already set up for use.
                         This option can be used to override clang-format 7.0.0.

```