### PR TITLE
Avoid hall of mirrors

### DIFF
--- a/Modules/CetProcessLiblist.cmake
+++ b/Modules/CetProcessLiblist.cmake
@@ -41,6 +41,10 @@ function(_cet_convert_target_arg ARG RESULT_VAR)
         set(${RESULT_VAR} PARENT_SCOPE)
         return()
       endif()
+      if ("${tmp}" STREQUAL "${ARG}") # Expands to self, avoid hall of mirrors...
+        set(${RESULT_VAR} "${tmp}")
+        return()
+      endif()
       unset(${${ARG}_UC}) # Prevent cycles.
       cet_convert_target_args(RESULT ${DEP_TARGET} "${tmp}")
     else()

--- a/Modules/CetProcessLiblist.cmake
+++ b/Modules/CetProcessLiblist.cmake
@@ -37,15 +37,17 @@ function(_cet_convert_target_arg ARG RESULT_VAR)
     if (${${ARG}_UC} MATCHES ";" OR NOT ${${ARG}_UC} MATCHES "/")
       # Possibly requiring further expansion:
       set(tmp "${${${ARG}_UC}}")
-      if ("${tmp}" STREQUAL "") # Empty.
-        set(${RESULT_VAR} PARENT_SCOPE)
+      if ("${tmp}" STREQUAL "" OR
+          "${tmp}" STREQUAL "${ARG}" OR
+          "${tmp}" STREQUAL "${${ARG}_UC}") 
+        #prevent cycles
+        set(${RESULT_VAR} "${tmp}" PARENT_SCOPE)
         return()
       endif()
       if ("${tmp}" STREQUAL "${ARG}") # Expands to self, avoid hall of mirrors...
         set(${RESULT_VAR} "${tmp}")
         return()
       endif()
-      unset(${${ARG}_UC}) # Prevent cycles.
       cet_convert_target_args(RESULT ${DEP_TARGET} "${tmp}")
     else()
       # Delay expansion for variables resolving to paths.

--- a/Modules/CetProcessLiblist.cmake
+++ b/Modules/CetProcessLiblist.cmake
@@ -44,10 +44,6 @@ function(_cet_convert_target_arg ARG RESULT_VAR)
         set(${RESULT_VAR} "${tmp}" PARENT_SCOPE)
         return()
       endif()
-      if ("${tmp}" STREQUAL "${ARG}") # Expands to self, avoid hall of mirrors...
-        set(${RESULT_VAR} "${tmp}")
-        return()
-      endif()
       cet_convert_target_args(RESULT ${DEP_TARGET} "${tmp}")
     else()
       # Delay expansion for variables resolving to paths.

--- a/Modules/compat/FindSQLite3.cmake
+++ b/Modules/compat/FindSQLite3.cmake
@@ -20,7 +20,7 @@ endif()
 # want to use NAMES_PER_DIR here.
 find_library(SQLite3_LIBRARY NAMES sqlite3_ups sqlite3 sqlite)
 set(_cet_sqlite_cmake_module_path "${CMAKE_MODULE_PATH}")
-set(CMAKE_MODULE_PATH "") # Don't want to find ourselves and loop.
+set(CMAKE_MODULE_PATH) # Don't want to find ourselves and loop.
 find_package(SQLite3)
 set(CMAKE_MODULE_PATH "${_cet_sqlite_cmake_module_path}")
 unset(_cet_sqlite_cmake_module_path)

--- a/Modules/compat/FindSQLite3.cmake
+++ b/Modules/compat/FindSQLite3.cmake
@@ -20,7 +20,7 @@ endif()
 # want to use NAMES_PER_DIR here.
 find_library(SQLite3_LIBRARY NAMES sqlite3_ups sqlite3 sqlite)
 set(_cet_sqlite_cmake_module_path "${CMAKE_MODULE_PATH}")
-set(CMAKE_MODULE_PATH) # Don't want to find ourselves and loop.
+set(CMAKE_MODULE_PATH "") # Don't want to find ourselves and loop.
 find_package(SQLite3)
 set(CMAKE_MODULE_PATH "${_cet_sqlite_cmake_module_path}")
 unset(_cet_sqlite_cmake_module_path)


### PR DESCRIPTION
if somehow, say, something ended up doing

set(PQ pq) 

and then later using PQ in a liblist, we recourse forever.  I think the unset(${ARG}_UC) call
is trying to avoid this, but it doesn't.. 

