### PR TITLE
Enable prepending to path-like environment variables

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -26,7 +26,7 @@
 # * Awareness of multi-project builds.
 #
 ########################################################################
-set(CETMODULES_MIN_CMAKE_VERSION 3.21) # Used in config/cetmodules-cmake-version-check.cmake
+set(CETMODULES_MIN_CMAKE_VERSION 3.22) # Used in config/cetmodules-cmake-version-check.cmake
 
 # Required to keep CMake happy.
 cmake_minimum_required(VERSION ${CETMODULES_MIN_CMAKE_VERSION}...3.27

--- a/Modules/CetTest.cmake
+++ b/Modules/CetTest.cmake
@@ -763,17 +763,17 @@ function(cet_test_env)
 endfunction()
 
 #[================================================================[.rst:
-.. command:: cet_test_prepend_env
+.. command:: cet_test_env_mod
 
-   Prepend to path-like environment variables in the test environment
-   for tests defined in and below the current directory.
+   Add environment modifications to the test environment for tests
+   defined in and below the current directory.
 
    .. seealso:: :variable:`CET_TEST_ENV_MODIFICATION`,
                 :prop_test:`cmake-ref-current:prop_test:ENVIRONMENT_MODIFICATION`.
 
    .. code-block:: cmake
 
-      cet_test_prepend_env(<var> [CLEAR] [REMOVE_DUPLICATES] <dir> ...)
+      cet_test_env_mod(<var> <op> [CLEAR] [REMOVE_DUPLICATES] <dir> ...)
 
    Options
    ^^^^^^^
@@ -788,17 +788,37 @@ endfunction()
 
 #]================================================================]
 
-function(cet_test_prepend_env CET_ENV_VAR)
-  cmake_parse_arguments(PARSE_ARGV 1 CET_TPE "CLEAR;REMOVE_DUPLICATES" "" "")
-  if (CET_TPE_CLEAR)
+function(cet_test_env_mod VAR OP)
+  cmake_parse_arguments(PARSE_ARGV 1 CET_TEM "CLEAR;REMOVE_DUPLICATES" "" "")
+  if (CET_TEM_CLEAR)
     set(CET_TEST_ENV_MODIFICATION)
   endif()
-  if (CET_TPE_REMOVE_DUPLICATES)
-    list(REMOVE_DUPLICATES CET_TPE_UNPARSED_ARGUMENTS)
+  if (CET_TEM_REMOVE_DUPLICATES)
+    list(REMOVE_DUPLICATES CET_TEM_UNPARSED_ARGUMENTS)
   endif()
-  string(REPLACE ";" ":" test_env_mod "${CET_TPE_UNPARSED_ARGUMENTS}")
+  string(REPLACE ";" ":" test_env_mod "${CET_TEM_UNPARSED_ARGUMENTS}")
   list(APPEND CET_TEST_ENV_MODIFICATION
-    "${CET_ENV_VAR}=path_list_prepend:${test_env_mod}")
+    "${VAR}=${OP}:${test_env_mod}")
+  set(CET_TEST_ENV_MODIFICATION "${CET_TEST_ENV_MODIFICATION}" PARENT_SCOPE)
+endfunction()
+
+#[================================================================[.rst:
+.. command:: cet_test_prepend_env
+
+   Prepend to path-like environment variables in the test environment
+   for tests defined in and below the current directory.
+
+   .. code-block:: cmake
+
+      cet_test_prepend_env(<var> ...)
+
+   Functionally identical to :command:`cet_test_env_mod(<var>
+   path_list_prepend ...)  <cet_test_env_mod>`
+
+#]================================================================]
+
+function(cet_test_prepend_env CET_ENV_VAR)
+  cet_test_env_mod(${CET_ENV_VAR} path_list_prepend ${ARGN})
   set(CET_TEST_ENV_MODIFICATION "${CET_TEST_ENV_MODIFICATION}" PARENT_SCOPE)
 endfunction()
 

--- a/Modules/CetTest.cmake
+++ b/Modules/CetTest.cmake
@@ -249,7 +249,7 @@ CetTest
 #
 # CLEAR
 #   Clear the global test environment (ie anything previously set with
-#    cet_test_env()) before setting <env>.
+#   cet_test_env()) before setting <env>.
 #
 ####################################
 # Notes:
@@ -261,6 +261,35 @@ CetTest
 #   for tests then that will be propagated to tests defined in
 #   subdirectories unless cet_test_env(CLEAR ...) is invoked in that
 #   directory.
+#
+########################################################################
+
+########################################################################
+# cet_test_prepend_env: prepend directories to the specified environment
+#                       variable all tests here specified.
+#
+# Usage: cet_test_prepend_env(<env> [<options] [<dir>+])
+#
+####################################
+# Options:
+#
+# REMOVE_DUPLICATES
+#   Remove any duplicate directory entries that may appear in the
+#   directories specified by the user.  For a given duplicate, only
+#   the first entry will be kept.
+#
+####################################
+# Notes:
+#
+# * <dir> is a directory string or generator expression whose
+# * evaluation will be prepended to the specified environment
+# * variable.  If no <dir> argument is given, then
+# * cet_test_prepend_env() is a NOP.
+#
+# * If cet_test_prepend_env() is called in a directory to set the
+#   environment for tests then that will be propagated to tests
+#   defined in subdirectories unless cet_test_env(CLEAR ...) is
+#   invoked in that directory.
 #
 ########################################################################
 
@@ -1006,6 +1035,41 @@ function(cet_test_env)
     set(CET_TEST_ENV)
   endif()
   list(APPEND CET_TEST_ENV "${CET_TEST_UNPARSED_ARGUMENTS}")
+  set(CET_TEST_ENV "${CET_TEST_ENV}" PARENT_SCOPE)
+endfunction()
+
+#[================================================================[.rst:
+.. command:: cet_test_prepend_env
+
+   Prepend to path-like environment variables to the test environment
+   for tests defined in and below the current directory.
+
+   .. code-block:: cmake
+
+      cet_test_prepend_env(<var> [REMOVE_DUPLICATES] <dir> ...)
+
+   Options
+   ^^^^^^^
+
+   ``REMOVE_DUPLICATES``
+     Remove any duplicate directory entries that may appear in the
+     specified directories.  For a given duplicate, only the first
+     entry will be kept.
+
+#]================================================================]
+
+function(cet_test_prepend_env CET_ENV_VAR)
+  cmake_parse_arguments(PARSE_ARGV 1 CET_TEST "REMOVE_DUPLICATES" "" "")
+  if (CET_TEST_REMOVE_DUPLICATES)
+    list(REMOVE_DUPLICATES CET_TEST_UNPARSED_ARGUMENTS)
+  endif()
+  string(REPLACE ";" ":" PREFIX "${CET_TEST_UNPARSED_ARGUMENTS}")
+  if (DEFINED ENV{${CET_ENV_VAR}})
+    set(PATHS "${CET_ENV_VAR}=${PREFIX}:$ENV{${CET_ENV_VAR}}")
+  else()
+    set(PATHS "${CET_ENV_VAR}=${PREFIX}")
+  endif()
+  list(APPEND CET_TEST_ENV "${PATHS}")
   set(CET_TEST_ENV "${CET_TEST_ENV}" PARENT_SCOPE)
 endfunction()
 

--- a/Modules/CetTest.cmake
+++ b/Modules/CetTest.cmake
@@ -735,7 +735,7 @@ endfunction()
      Clear the test environment in the current directory scope prior to
      setting ``<var>=<val>``, including any environment modifications.
 
-     .. seealso:: :command:`cet_prepend_test_environment`,
+     .. seealso:: :command:`cet_test_prepend_env`,
                   :variable:`CET_TEST_ENV_MODIFICATION`.
 
    Details

--- a/Modules/CetTest.cmake
+++ b/Modules/CetTest.cmake
@@ -735,7 +735,7 @@ endfunction()
      Clear the test environment in the current directory scope prior to
      setting ``<var>=<val>``, including any environment modifications.
 
-     .. seealso:: :command:`cet_test_prepend_env`,
+     .. seealso:: :command:`cet_test_env_prepend`,
                   :variable:`CET_TEST_ENV_MODIFICATION`.
 
    Details
@@ -803,21 +803,21 @@ function(cet_test_env_mod VAR OP)
 endfunction()
 
 #[================================================================[.rst:
-.. command:: cet_test_prepend_env
+.. command:: cet_test_env_prepend
 
    Prepend to path-like environment variables in the test environment
    for tests defined in and below the current directory.
 
    .. code-block:: cmake
 
-      cet_test_prepend_env(<var> ...)
+      cet_test_env_prepend(<var> ...)
 
    Functionally identical to :command:`cet_test_env_mod(<var>
    path_list_prepend ...)  <cet_test_env_mod>`
 
 #]================================================================]
 
-function(cet_test_prepend_env CET_ENV_VAR)
+function(cet_test_env_prepend CET_ENV_VAR)
   cet_test_env_mod(${CET_ENV_VAR} path_list_prepend ${ARGN})
   set(CET_TEST_ENV_MODIFICATION "${CET_TEST_ENV_MODIFICATION}" PARENT_SCOPE)
 endfunction()

--- a/Modules/CetTest.cmake
+++ b/Modules/CetTest.cmake
@@ -612,11 +612,24 @@ test ${test} must be defined already to be specified as a fixture for ${CET_TARG
     endforeach()
     foreach (target IN LISTS ALL_TEST_TARGETS)
       if (CET_TEST_ENV)
-        set_property(TEST ${target} APPEND PROPERTY ENVIRONMENT ${CET_TEST_ENV})
+        get_test_property(${target} ENVIRONMENT CET_TEST_ENV_TMP)
+        if (CET_TEST_ENV_TMP)
+          set_tests_properties(${target} PROPERTIES
+            ENVIRONMENT "${CET_TEST_ENV};${CET_TEST_ENV_TMP}")
+        else()
+          set_tests_properties(${target} PROPERTIES
+            ENVIRONMENT "${CET_TEST_ENV}")
+        endif()
       endif()
       if (CET_TEST_ENV_MODIFICATION)
-        set_property(TEST ${target} APPEND PROPERTY
-          ENVIRONMENT_MODIFICATION ${CET_TEST_ENV_MODIFICATION})
+        get_test_property(${target} ENVIRONMENT_MODIFICATION CET_TEST_ENV_TMP)
+        if (CET_TEST_ENV_TMP)
+          set_tests_properties(${target} PROPERTIES
+            ENVIRONMENT_MODIFICATION "${CET_TEST_ENV_MODIFICATION};${CET_TEST_ENV_TMP}")
+        else()
+          set_tests_properties(${target} PROPERTIES
+            ENVIRONMENT_MODIFICATION "${CET_TEST_ENV_MODIFICATION}")
+        endif()
       endif()
       if (CET_REF)
         get_test_property(${target} REQUIRED_FILES REQUIRED_FILES_TMP)
@@ -786,7 +799,7 @@ function(cet_test_prepend_env CET_ENV_VAR)
   string(REPLACE ";" ":" test_env_mod "${CET_TPE_UNPARSED_ARGUMENTS}")
   list(APPEND CET_TEST_ENV_MODIFICATION
     "${CET_ENV_VAR}=path_list_prepend:${test_env_mod}")
-  set(CET_TEST_ENV_MODIFICATION "${CET_TEST_ENV_MODIFICATION}")
+  set(CET_TEST_ENV_MODIFICATION "${CET_TEST_ENV_MODIFICATION}" PARENT_SCOPE)
 endfunction()
 
 function(_cet_add_ref_test)

--- a/doc/reference/manual/cetmodules-commands.7.rst
+++ b/doc/reference/manual/cetmodules-commands.7.rst
@@ -64,6 +64,7 @@ Utility
 * :command:`cet_source_file_extensions`
 * :command:`cet_test_assertion`
 * :command:`cet_test_env`
+* :command:`cet_test_prepend_env`
 * :command:`cet_timestamp`
 * :command:`cet_version_cmp`
 * :command:`parse_version_string`

--- a/doc/reference/manual/cetmodules-commands.7.rst
+++ b/doc/reference/manual/cetmodules-commands.7.rst
@@ -65,7 +65,7 @@ Utility
 * :command:`cet_test_assertion`
 * :command:`cet_test_env`
 * :command:`cet_test_env_mod`
-* :command:`cet_test_prepend_env`
+* :command:`cet_test_env_prepend`
 * :command:`cet_timestamp`
 * :command:`cet_version_cmp`
 * :command:`parse_version_string`

--- a/doc/reference/manual/cetmodules-commands.7.rst
+++ b/doc/reference/manual/cetmodules-commands.7.rst
@@ -64,6 +64,7 @@ Utility
 * :command:`cet_source_file_extensions`
 * :command:`cet_test_assertion`
 * :command:`cet_test_env`
+* :command:`cet_test_env_mod`
 * :command:`cet_test_prepend_env`
 * :command:`cet_timestamp`
 * :command:`cet_version_cmp`

--- a/doc/reference/variable/CET_TEST_ENV.rst
+++ b/doc/reference/variable/CET_TEST_ENV.rst
@@ -6,5 +6,5 @@ A directory-scope variable containing an initial value of the
 property for tests defined by :command:`cet_test`. Modify with
 :command:`cet_test_env`.
 
-.. seealso:: :command:`cet_test_prepend_env`,
+.. seealso:: :command:`cet_test_env_prepend`,
              :variable:`CET_TEST_ENV_MODIFICATION`.

--- a/doc/reference/variable/CET_TEST_ENV.rst
+++ b/doc/reference/variable/CET_TEST_ENV.rst
@@ -1,0 +1,10 @@
+CET_TEST_ENV
+------------
+
+A directory-scope variable containing an initial value of the
+:prop_test:`ENVIRONMENT <cmake-ref-current:prop_test:ENVIRONMENT>`
+property for tests defined by :command:`cet_test`. Modify with
+:command:`cet_test_env`.
+
+.. seealso:: :command:`cet_test_prepend_env`,
+             :variable:`CET_TEST_ENV_MODIFICATION`.

--- a/doc/reference/variable/CET_TEST_ENV_MODIFICATION.rst
+++ b/doc/reference/variable/CET_TEST_ENV_MODIFICATION.rst
@@ -5,6 +5,6 @@ A directory-scope variable containing an initial value of the
 :prop_test:`ENVIRONMENT_MODIFICATION
 <cmake-ref-current:prop_test:ENVIRONMENT_MODIFICATION>` property for
 tests defined by :command:`cet_test`. Modify with
-:command:`cet_test_prepend_env`.
+:command:`cet_test_env_prepend`.
 
 .. seealso:: :command:`cet_test_env`, :variable:`CET_TEST_ENV`.

--- a/doc/reference/variable/CET_TEST_ENV_MODIFICATION.rst
+++ b/doc/reference/variable/CET_TEST_ENV_MODIFICATION.rst
@@ -1,0 +1,10 @@
+CET_TEST_ENV_MODIFICATION
+-------------------------
+
+A directory-scope variable containing an initial value of the
+:prop_test:`ENVIRONMENT_MODIFICATION
+<cmake-ref-current:prop_test:ENVIRONMENT_MODIFICATION>` property for
+tests defined by :command:`cet_test`. Modify with
+:command:`cet_test_prepend_env`.
+
+.. seealso:: :command:`cet_test_env`, :variable:`CET_TEST_ENV`.


### PR DESCRIPTION
The function `cet_test_prepend_env(...)` allows for a simpler mechanism of prepending to a path-like environment variable (e.g.):

```diff
- cet_test_env("LD_LIBRARY_PATH=${dir1}:${dir2}:${dir3}:$ENV{LD_LIBRARY_PATH}")
+ cet_test_prepend_env(LD_LIBRARY_PATH ${dir1} ${dir2} ${dir3})
```