### PR TITLE
Set LD_LIBRARY_PATH and ROOT_INCLUDE_PATH within CheckClassVersion

### DIFF
--- a/Modules/CheckClassVersion.cmake
+++ b/Modules/CheckClassVersion.cmake
@@ -135,6 +135,10 @@ function(check_class_version)
       list(APPEND CMD_ENV "${ev}=$ENV{${ev}}")
     endif()
   endforeach()
+  if (TARGET ${dictname}_dict)
+    list(APPEND CMD_ENV "LD_LIBRARY_PATH=$<GENEX_EVAL:$<JOIN:$<TARGET_PROPERTY:${dictname}_dict,LINK_DIRECTORIES>,:>>")
+    list(APPEND CMD_ENV "ROOT_INCLUDE_PATH=$<GENEX_EVAL:$<JOIN:$<TARGET_PROPERTY:${dictname}_dict,INCLUDE_DIRECTORIES>,:>>")
+  endif()
   # Add the check to the end of the dictionary building step.
   add_custom_command(OUTPUT ${dictname}_dict_checked
     COMMAND ${CMAKE_COMMAND} -E env ${CMD_ENV} ${CCV_ENVIRONMENT}

--- a/Modules/CheckClassVersion.cmake
+++ b/Modules/CheckClassVersion.cmake
@@ -136,8 +136,8 @@ function(check_class_version)
     endif()
   endforeach()
   if (TARGET ${dictname}_dict)
-    list(APPEND CMD_ENV "LD_LIBRARY_PATH=$<GENEX_EVAL:$<JOIN:$<TARGET_PROPERTY:${dictname}_dict,LINK_DIRECTORIES>,:>>")
-    list(APPEND CMD_ENV "ROOT_INCLUDE_PATH=$<GENEX_EVAL:$<JOIN:$<TARGET_PROPERTY:${dictname}_dict,INCLUDE_DIRECTORIES>,:>>")
+    list(APPEND CMD_ENV "LD_LIBRARY_PATH=$<JOIN:$<TARGET_PROPERTY:${dictname}_dict,LINK_DIRECTORIES>,:>")
+    list(APPEND CMD_ENV "ROOT_INCLUDE_PATH=$<JOIN:$<TARGET_PROPERTY:${dictname}_dict,INCLUDE_DIRECTORIES>,:>")
   endif()
   # Add the check to the end of the dictionary building step.
   add_custom_command(OUTPUT ${dictname}_dict_checked


### PR DESCRIPTION
In a Spack user environment, `LD_LIBRARY_PATH` and `ROOT_INCLUDE_PATH` are not fully populated (or even available).  This PR populates the environment variables as part of the `add_custom_command(...)` invocation.