### PR TITLE
Add cet_transitive_paths() function

### DIFF
--- a/Modules/CetTest.cmake
+++ b/Modules/CetTest.cmake
@@ -21,6 +21,8 @@ include(CetMake)
 include(CetPackagePath)
 # May need to escape a string to avoid misinterpretation as regex
 include(CetRegexEscape)
+# Need to specify transitive BINARY_DIR paths for COMPILE_ONLY tests
+include(CetTransitivePaths)
 
 ##################
 # Programs and Modules
@@ -688,8 +690,8 @@ test ${test} must be defined already to be specified as a fixture for ${CET_TARG
         endif()
       endif()
       if (CET_COMPILE_ONLY)
-        _transitive_binary_directories(${CETMODULES_CURRENT_PROJECT_NAME})
-        list(JOIN TRANSITIVE_BINARY_DIRS ":" DIRS_FOR_PREFIX_PATH)
+        cet_transitive_paths(BINARY_DIR IN_TREE)
+        list(JOIN TRANSITIVE_PATHS_WITH_BINARY_DIR ":" DIRS_FOR_PREFIX_PATH)
         set(TEST_CMAKE_PREFIX_PATH "CMAKE_PREFIX_PATH=path_list_prepend:${DIRS_FOR_PREFIX_PATH}")
         get_test_property(${target} ENVIRONMENT_MODIFICATION CET_TEST_ENV_TMP)
         if (CET_TEST_ENV_TMP)
@@ -1099,16 +1101,4 @@ function(_update_defined_test_groups)
     CACHE STRING "List of defined test groups."
     FORCE
     )
-endfunction()
-
-function(_transitive_binary_directories PKG)
-  set(TRANSITIVE_BINARY_DIRS_TMP ${${PKG}_BINARY_DIR})
-  foreach(DEP IN LISTS CETMODULES_FIND_DEPS_PNAMES_PROJECT_${PKG})
-    if (${DEP}_IN_TREE)
-      _transitive_binary_directories(${DEP})
-      list(APPEND TRANSITIVE_BINARY_DIRS_TMP ${TRANSITIVE_BINARY_DIRS})
-    endif()
-  endforeach()
-  list(REMOVE_DUPLICATES TRANSITIVE_BINARY_DIRS_TMP)
-  set(TRANSITIVE_BINARY_DIRS ${TRANSITIVE_BINARY_DIRS_TMP} PARENT_SCOPE)
 endfunction()

--- a/Modules/CetTransitivePaths.cmake
+++ b/Modules/CetTransitivePaths.cmake
@@ -27,6 +27,7 @@ include_guard()
 
       cet_transitive_paths(<path-name> [<project-variable localization options>] [IN_TREE] [PROJECT <project-name>])
 
+   .. seealso:: :command:`cet_localize_pv`.
    Options
    ^^^^^^^
 

--- a/Modules/CetTransitivePaths.cmake
+++ b/Modules/CetTransitivePaths.cmake
@@ -1,0 +1,88 @@
+#[================================================================[.rst:
+CetTransitivePaths
+------------------
+
+Defines the function :commmand:`cet_transitive_paths`.
+
+#]================================================================]
+
+include_guard()
+
+#[================================================================[.rst:
+.. command:: cet_transitive_paths
+
+
+   Get a list of path values for all transitive dependencies of the
+   given project name.  For a given path name, the dependency tree of
+   the given project is searched according to the dependencies
+   specified via ``find_package``.
+
+   For example, if the path name ``"MY_PATH"`` is supplied, the
+   function will traverse the dependency structure and collect all
+   values of the path name ``"<project-or-dependency name>_MY_PATH"``.
+   The result can be accessed via the variable
+   ``"TRANSITIVE_PATHS_WITH_MY_PATH"``.
+
+   .. code-block:: cmake
+
+      cet_transitive_paths(<path-name> [<project-variable localization options>] [IN_TREE] [PROJECT <project-name>])
+
+   Options
+   ^^^^^^^
+
+   ``[PROJECT] <project-name>``
+     The top-level project from which the transitive dependency
+     traversal occurs.  (default
+     :variable:`${CETMODULES_CURRENT_PROJECT_NAME}
+     <CETMODULES_CURRENT_PROJECT_NAME>`).
+
+   ``[IN_TREE]``
+     Include paths only from projects that are included in the build tree.
+
+   Non-option arguments
+   ^^^^^^^^^^^^^^^^^^^^
+
+   ``<path-name>``
+     The name of the path that serves as the suffix for the top-level
+     project and all transitive dependencies.  The path name can be a
+     Cetmodules project variable, in which case the options to
+     :command:`cet_localize_pv` may also be provided.
+
+#]================================================================]
+
+function(cet_transitive_paths PATH)
+  cmake_parse_arguments(PARSE_ARGV 1 CTP "IN_TREE;BINARY;SOURCE;TRY_BINARY" "PROJECT" "")
+  cet_passthrough(FLAG APPEND CTP_BINARY clpv_args)
+  cet_passthrough(FLAG APPEND CTP_SOURCE clpv_args)
+  cet_passthrough(FLAG APPEND CTP_TRY_BINARY clpv_args)
+
+  set(PKG ${CETMODULES_CURRENT_PROJECT_NAME})
+  if (CTP_PROJECT)
+    set(PKG ${CTP_PROJECT})
+  endif()
+
+  _cet_transitive_project_names(${PKG} PNAMES_RESULT CTP_IN_TREE)
+  foreach(DEP IN LISTS PNAMES_RESULT)
+    if (DEFINED CACHE{CETMODULES_${PATH}_PROPERTIES_PROJECT_${DEP}})
+      cet_localize_pv(${DEP} ${PATH} ${clpv_args})
+    endif()
+    list(APPEND TRANSITIVE_PATHS_TMP ${${DEP}_${PATH}})
+  endforeach()
+  set(TRANSITIVE_PATHS_WITH_${PATH} ${TRANSITIVE_PATHS_TMP} PARENT_SCOPE)
+
+endfunction()
+
+function(_cet_transitive_project_names PKG RESULT_LIST)
+  set(RESULT_LIST_TMP ${${RESULT_LIST}})
+  foreach(DEP IN LISTS CETMODULES_FIND_DEPS_PNAMES_PROJECT_${PKG})
+    if (PKG STREQUAL DEP OR
+        (ARGN STREQUAL "IN_TREE" AND NOT ${DEP}_IN_TREE))
+      continue()
+    endif()
+    if (NOT "${DEP}" IN_LIST RESULT_LIST_TMP)
+      _cet_transitive_project_names("${DEP}" RESULT_LIST_TMP ${ARGN})
+    endif()
+  endforeach()
+  list(PREPEND RESULT_LIST_TMP ${PKG})
+  set(${RESULT_LIST} ${RESULT_LIST_TMP} PARENT_SCOPE)
+endfunction()

--- a/Modules/CetTransitivePaths.cmake
+++ b/Modules/CetTransitivePaths.cmake
@@ -27,7 +27,8 @@ include_guard()
 
       cet_transitive_paths(<path-name> [<project-variable localization options>] [IN_TREE] [PROJECT <project-name>])
 
-   .. seealso:: :command:`cet_localize_pv`.
+   .. seealso:: :command:`cet_localize_pv`
+
    Options
    ^^^^^^^
 
@@ -52,36 +53,32 @@ include_guard()
 #]================================================================]
 
 function(cet_transitive_paths PATH)
-  cmake_parse_arguments(PARSE_ARGV 1 CTP "IN_TREE;BINARY;SOURCE;TRY_BINARY" "PROJECT" "")
-  cet_passthrough(FLAG APPEND CTP_BINARY clpv_args)
-  cet_passthrough(FLAG APPEND CTP_SOURCE clpv_args)
-  cet_passthrough(FLAG APPEND CTP_TRY_BINARY clpv_args)
+  cmake_parse_arguments(PARSE_ARGV 1 CTP "IN_TREE" "PROJECT" "")
 
   set(PKG ${CETMODULES_CURRENT_PROJECT_NAME})
   if (CTP_PROJECT)
     set(PKG ${CTP_PROJECT})
   endif()
 
-  _cet_transitive_project_names(${PKG} PNAMES_RESULT CTP_IN_TREE)
+  _cet_transitive_project_names(${PKG} PNAMES_RESULT)
   foreach(DEP IN LISTS PNAMES_RESULT)
     if (DEFINED CACHE{CETMODULES_${PATH}_PROPERTIES_PROJECT_${DEP}})
-      cet_localize_pv(${DEP} ${PATH} ${clpv_args})
+      cet_localize_pv(${DEP} ${PATH} ${CTP_UNPARSED_ARGUMENTS})
     endif()
     list(APPEND TRANSITIVE_PATHS_TMP ${${DEP}_${PATH}})
   endforeach()
   set(TRANSITIVE_PATHS_WITH_${PATH} ${TRANSITIVE_PATHS_TMP} PARENT_SCOPE)
-
 endfunction()
 
 function(_cet_transitive_project_names PKG RESULT_LIST)
   set(RESULT_LIST_TMP ${${RESULT_LIST}})
   foreach(DEP IN LISTS CETMODULES_FIND_DEPS_PNAMES_PROJECT_${PKG})
     if (PKG STREQUAL DEP OR
-        (ARGN STREQUAL "IN_TREE" AND NOT ${DEP}_IN_TREE))
+        (CTP_IN_TREE AND NOT ${DEP}_IN_TREE))
       continue()
     endif()
     if (NOT "${DEP}" IN_LIST RESULT_LIST_TMP)
-      _cet_transitive_project_names("${DEP}" RESULT_LIST_TMP ${ARGN})
+      _cet_transitive_project_names("${DEP}" RESULT_LIST_TMP)
     endif()
   endforeach()
   list(PREPEND RESULT_LIST_TMP ${PKG})

--- a/doc/reference/manual/cetmodules-commands.7.rst
+++ b/doc/reference/manual/cetmodules-commands.7.rst
@@ -70,6 +70,7 @@ Utility
 * :command:`cet_test_env_mod`
 * :command:`cet_test_env_prepend`
 * :command:`cet_timestamp`
+* :command:`cet_transitive_paths`
 * :command:`cet_version_cmp`
 * :command:`cet_write_plugin_builder`
 * :command:`parse_version_string`

--- a/doc/reference/module/CetTransitivePaths.rst
+++ b/doc/reference/module/CetTransitivePaths.rst
@@ -1,0 +1,1 @@
+.. cmake-module:: /../../Modules/CetTransitivePaths.cmake


### PR DESCRIPTION
This function accepts a path name and a project name (default is the current project name).  For each transitive dependency of the specificied project name, the value of the corresponding path name is appended to an output variable.