### PR TITLE
Revert to `find_package()` override instead of `SET_DEPENDENCY_PROVIDER`

### DIFF
--- a/Modules/CetCMakeConfig.cmake
+++ b/Modules/CetCMakeConfig.cmake
@@ -88,7 +88,7 @@ include(ProjectVariable)
 #]================================================================]
 
 function(cet_cmake_config)
-  if(NOT COMMAND cet_provide_dependency)
+  if(NOT COMMAND _cet_fp_parse_args)
     message(
       FATAL_ERROR
         "cet_cmake_config() requires

--- a/Modules/CetProvideDependency.cmake
+++ b/Modules/CetProvideDependency.cmake
@@ -53,6 +53,13 @@ X
 # * From the point of view of find_package(), INTERFACE AND EXPORT are
 #   identical: a find_package() call will be executed either way in order to
 #   ensure that targets, etc., are known to CMake at the appropriate time.
+# ##############################################################################
+
+# ##############################################################################
+# N.B. We override `find_package()` directly rather than using the
+# `cmake_language(SET_DEPENDENCY_PROVIDER)` due to the latter's
+# restrictions on the version argument and any new flags or options.
+# ##############################################################################
 
 # Once only per directory!
 include_guard()


### PR DESCRIPTION
The dependency provider mechanism has limitations on argument passage
via `find_package()` that render it unworkable for our purposes.

Revert to the older macro override method from Cetmodules 3 while
retaining the default use of `CMAKE_PROJECT_TOP_LEVEL_INCLUDES` to
activate the override. This should enable straightforward use within
e.g. MPD.
