### PR TITLE
fix(cet_exec_test): Ensure BSD getopt compatibility

### DIFF
--- a/libexec/cet_exec_test
+++ b/libexec/cet_exec_test
@@ -43,33 +43,75 @@ function set_datafiles() {
 # Main.
 ########################################################################
 
-getopt -T >/dev/null 2>&1
-if (( $? != 4 )); then
-  echo "ERROR: GNU getopt required! Check SETUP_GETOPT and PATH." 1>&2
-  exit 1
-fi
-
-TEMP=`getopt -n "$prog" --long datafiles:,debug,dirty-workdir,remove-on-failure:,required-files:,skip-return-code:,wd: -o + -- "${@}"`
-eval set -- "$TEMP"
-
-while true; do
-  case $1 in
-    --datafiles) set_datafiles "$2"; shift;;
-    --debug) vopt="v";;
-    --dirty-workdir) unset want_clean;;
+# Manual parsing of command-line arguments.
+declare -a remaining_args
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --datafiles)
+      set_datafiles "$2"
+      shift 2
+      ;;
+    --datafiles=*)
+      set_datafiles "${1#*=}"
+      shift
+      ;;
+    --debug)
+      vopt="v"
+      shift
+      ;;
+    --dirty-workdir)
+      unset want_clean
+      shift
+      ;;
     --remove-on-failure)
       old_IFS="${IFS}"; IFS=';'; removeOnFailure=($2); IFS=${old_IFS}
-      shift;;
+      shift 2
+      ;;
+    --remove-on-failure=*)
+      old_IFS="${IFS}"; IFS=';'; removeOnFailure=(${1#*=}); IFS=${old_IFS}
+      shift
+      ;;
     --required-files)
       old_IFS="${IFS}"; IFS=';'; requiredfiles=($2); IFS=${old_IFS}
-      shift;;
-    --skip-return-code) (( skip_code = ${2} )); shift;;
-    --wd) wd="$2"; shift;;
-    --) shift; break;;
-    *) echo "Bad argument $1" 1>&2; usage 1
+      shift 2
+      ;;
+    --required-files=*)
+      old_IFS="${IFS}"; IFS=';'; requiredfiles=(${1#*=}); IFS=${old_IFS}
+      shift
+      ;;
+    --skip-return-code)
+      (( skip_code = ${2} ))
+      shift 2
+      ;;
+    --skip-return-code=*)
+      (( skip_code = ${1#*=} ))
+      shift
+      ;;
+    --wd)
+      wd="$2"
+      shift 2
+      ;;
+    --wd=*)
+      wd="${1#*=}"
+      shift
+      ;;
+    --)
+      shift
+      remaining_args+=( "$@" )
+      break
+      ;;
+    -*)
+      echo "Bad argument $1" 1>&2; usage 1
+      ;;
+    *)
+      remaining_args+=( "$@" )
+      break # Stop processing at the first non-option argument
+      ;;
   esac
-  shift
 done
+
+# Restore the positional parameters
+eval set -- "${remaining_args[@]}"
 
 if [[ -z "$wd" ]]; then
   echo "Compulsory argument --wd missing." 1>&2

--- a/libexec/cet_exec_test
+++ b/libexec/cet_exec_test
@@ -48,6 +48,10 @@ declare -a remaining_args
 while [[ $# -gt 0 ]]; do
   case "$1" in
     --datafiles)
+      if [[ -z "$2" || "$2" == -* ]]; then
+        echo "ERROR: --datafiles requires an argument" 1>&2
+        usage 1
+      fi
       set_datafiles "$2"
       shift 2
       ;;
@@ -64,6 +68,10 @@ while [[ $# -gt 0 ]]; do
       shift
       ;;
     --remove-on-failure)
+      if [[ -z "$2" || "$2" == -* ]]; then
+        echo "ERROR: --remove-on-failure requires an argument" 1>&2
+        usage 1
+      fi
       old_IFS="${IFS}"; IFS=';'; removeOnFailure=($2); IFS=${old_IFS}
       shift 2
       ;;
@@ -72,6 +80,10 @@ while [[ $# -gt 0 ]]; do
       shift
       ;;
     --required-files)
+      if [[ -z "$2" || "$2" == -* ]]; then
+        echo "ERROR: --required-files requires an argument" 1>&2
+        usage 1
+      fi
       old_IFS="${IFS}"; IFS=';'; requiredfiles=($2); IFS=${old_IFS}
       shift 2
       ;;
@@ -80,6 +92,10 @@ while [[ $# -gt 0 ]]; do
       shift
       ;;
     --skip-return-code)
+      if [[ -z "$2" || "$2" == -* ]]; then
+        echo "ERROR: --skip-return-code requires an argument" 1>&2
+        usage 1
+      fi
       (( skip_code = ${2} ))
       shift 2
       ;;
@@ -88,6 +104,10 @@ while [[ $# -gt 0 ]]; do
       shift
       ;;
     --wd)
+      if [[ -z "$2" || "$2" == -* ]]; then
+        echo "ERROR: --wd requires an argument" 1>&2
+        usage 1
+      fi
       wd="$2"
       shift 2
       ;;
@@ -111,7 +131,7 @@ while [[ $# -gt 0 ]]; do
 done
 
 # Restore the positional parameters
-eval set -- "${remaining_args[@]}"
+set -- "${remaining_args[@]}"
 
 if [[ -z "$wd" ]]; then
   echo "Compulsory argument --wd missing." 1>&2


### PR DESCRIPTION
The `cet_exec_test` script previously used GNU `getopt` to parse command-line arguments, which is not available on macOS by default. This caused the script to fail when run on macOS.

This change replaces the `getopt` call with a manual, POSIX-compliant parsing loop. This new implementation preserves the existing command-line syntax and semantics, including support for long options with and without `=`, while ensuring the script runs correctly on both Linux and macOS.
